### PR TITLE
feat: infinite loop when claiming the last key in a drop

### DIFF
--- a/src/features/drop-manager/components/MissingDropModal.tsx
+++ b/src/features/drop-manager/components/MissingDropModal.tsx
@@ -1,0 +1,14 @@
+export const setMissingDropModal = (setAppModal, buttonProps = {}) => {
+  setAppModal({
+    isOpen: true,
+    header: 'This drop has no more keys',
+    message: `You will be reverted back to all drops`,
+    options: [
+      {
+        label: 'Ok',
+        func: () => null,
+        buttonProps,
+      },
+    ],
+  });
+};

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -25,6 +25,7 @@ import { tableColumns } from '../../components/TableColumn';
 import { INITIAL_SAMPLE_DATA } from '../../constants/common';
 import { setConfirmationModalHelper } from '../../components/ConfirmationModal';
 import { setMasterKeyValidityModal } from '../../components/MasterKeyValidityModal';
+import { setMissingDropModal } from '../../components/MissingDropModal';
 
 export default function NFTDropManagerPage() {
   const navigate = useNavigate();
@@ -94,6 +95,9 @@ export default function NFTDropManagerPage() {
     if (!accountId) return;
     let drop = await getDropInformation({
       dropId,
+    }).catch((_) => {
+      setMissingDropModal(setAppModal);
+      navigate('/drops');
     });
     if (!drop)
       drop = {

--- a/src/features/drop-manager/routes/ticket/[id].tsx
+++ b/src/features/drop-manager/routes/ticket/[id].tsx
@@ -29,6 +29,7 @@ import { INITIAL_SAMPLE_DATA } from '../../constants/common';
 import { type TicketClaimStatus } from '../../types/types';
 import { setConfirmationModalHelper } from '../../components/ConfirmationModal';
 import { setMasterKeyValidityModal } from '../../components/MasterKeyValidityModal';
+import { setMissingDropModal } from '../../components/MissingDropModal';
 
 export default function TicketDropManagerPage() {
   const navigate = useNavigate();
@@ -137,6 +138,9 @@ export default function TicketDropManagerPage() {
     if (!accountId) return;
     let drop = await getDropInformation({
       dropId,
+    }).catch((_) => {
+      setMissingDropModal(setAppModal);
+      navigate('/drops');
     });
     if (!drop)
       drop = {

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -25,6 +25,7 @@ import { tableColumns } from '../../components/TableColumn';
 import { INITIAL_SAMPLE_DATA } from '../../constants/common';
 import { setConfirmationModalHelper } from '../../components/ConfirmationModal';
 import { setMasterKeyValidityModal } from '../../components/MasterKeyValidityModal';
+import { setMissingDropModal } from '../../components/MissingDropModal';
 
 export default function TokenDropManagerPage() {
   const navigate = useNavigate();
@@ -93,6 +94,9 @@ export default function TokenDropManagerPage() {
     if (!accountId) return null;
     let drop = await getDropInformation({
       dropId,
+    }).catch((_) => {
+      setMissingDropModal(setAppModal);
+      navigate('/drops');
     });
     if (!drop) {
       // TODO Show error


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Deleting the last key in a drop will push the user back to All Drops and showing a modal saying that the drop has run out of keys

Fixes #146

# How to test
Show steps to replicate and test the feature/fixes in this PR

1. Go to All Drops
2. Select a drop
3. Claim all key by deleting them

# Screenshots/Screen Recording of Implementation

https://user-images.githubusercontent.com/40631483/221475272-ce26b540-22c5-480e-9dd7-7fe9e03ba69b.mov

