### PR TITLE
feat: dropmetadata throwing error

### DIFF
--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -164,7 +164,7 @@ export default function AllDrops() {
             ft,
             nft,
             fc,
-            metadata = JSON.stringify({ dropName: 'untitled' }),
+            metadata = JSON.stringify({ dropName: 'Untitled' }),
             next_key_id,
           }) => {
             const meta = JSON.parse(metadata) || {};

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -37,15 +37,14 @@ import { handleFinishNFTDrop } from '@/features/create-drop/contexts/CreateNftDr
 import { truncateAddress } from '@/utils/truncateAddress';
 import { NextButton, PrevButton } from '@/components/Pagination';
 import { usePagination } from '@/hooks/usePagination';
-import getConfig from '@/config/config';
 import { asyncWithTimeout } from '@/utils/asyncWithTimeout';
 import { useAppContext } from '@/contexts/AppContext';
+import { CLOUDFLARE_IPFS, DROP_TYPE } from '@/constants/common';
 
 import { MENU_ITEMS } from '../config/menuItems';
 
 import { MobileDrawerMenu } from './MobileDrawerMenu';
 import { setConfirmationModalHelper } from './ConfirmationModal';
-import { CLOUDFLARE_IPFS } from '@/constants/common';
 
 const FETCH_NFT_METHOD_NAME = 'get_series_info';
 
@@ -167,7 +166,7 @@ export default function AllDrops() {
           const type = getDropTypeLabel({ simple, ft, nft, fc });
 
           let nftHref = '';
-          if (type === 'NFT') {
+          if (type === DROP_TYPE.NFT) {
             const fcMethod = (fc as ProtocolReturnedFCData).methods[0]?.[0];
             const { receiver_id } = fcMethod as ProtocolReturnedMethod;
 
@@ -192,7 +191,7 @@ export default function AllDrops() {
             id,
             name: truncateAddress(meta.dropName, 'end', 48),
             type,
-            media: type === 'NFT' ? nftHref : undefined,
+            media: type === DROP_TYPE.NFT ? nftHref : undefined,
             claimed: `${
               next_key_id - (await getKeySupplyForDrop({ dropId: id }))
             } / ${next_key_id}`,

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -45,6 +45,7 @@ import { MENU_ITEMS } from '../config/menuItems';
 
 import { MobileDrawerMenu } from './MobileDrawerMenu';
 import { setConfirmationModalHelper } from './ConfirmationModal';
+import { CLOUDFLARE_IPFS } from '@/constants/common';
 
 const FETCH_NFT_METHOD_NAME = 'get_series_info';
 
@@ -183,7 +184,7 @@ export default function AllDrops() {
             });
 
             nftHref =
-              `${getConfig().cloudflareIfps as string}/${nftData?.metadata?.media as string}` ??
+              `${CLOUDFLARE_IPFS}/${nftData?.metadata?.media as string}` ??
               'https://placekitten.com/200/300';
           }
 

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -40,6 +40,7 @@ import { usePagination } from '@/hooks/usePagination';
 import { asyncWithTimeout } from '@/utils/asyncWithTimeout';
 import { useAppContext } from '@/contexts/AppContext';
 import { CLOUDFLARE_IPFS, DROP_TYPE } from '@/constants/common';
+import keypomInstance from '@/lib/keypom';
 
 import { MENU_ITEMS } from '../config/menuItems';
 
@@ -158,10 +159,7 @@ export default function AllDrops() {
     setData(
       await Promise.all(
         drops.map(async ({ drop_id: id, simple, ft, nft, fc, metadata, next_key_id }) => {
-          const meta = JSON.parse(metadata || '{}');
-          if (!meta.dropName) {
-            meta.dropName = 'Untitled';
-          }
+          const { dropName } = keypomInstance.getDropMetadata(metadata as string);
 
           const type = getDropTypeLabel({ simple, ft, nft, fc });
 
@@ -189,7 +187,7 @@ export default function AllDrops() {
 
           return {
             id,
-            name: truncateAddress(meta.dropName, 'end', 48),
+            name: truncateAddress(dropName, 'end', 48),
             type,
             media: type === DROP_TYPE.NFT ? nftHref : undefined,
             claimed: `${

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -157,56 +157,46 @@ export default function AllDrops() {
 
     setData(
       await Promise.all(
-        drops.map(
-          async ({
-            drop_id: id,
-            simple,
-            ft,
-            nft,
-            fc,
-            metadata = JSON.stringify({ dropName: 'Untitled' }),
-            next_key_id,
-          }) => {
-            const meta = JSON.parse(metadata) || {};
-            if (!meta.dropName) {
-              meta.dropName = 'Untitled Drop';
-            }
+        drops.map(async ({ drop_id: id, simple, ft, nft, fc, metadata, next_key_id }) => {
+          const meta = JSON.parse(metadata || '{}');
+          if (!meta.dropName) {
+            meta.dropName = 'Untitled';
+          }
 
-            const type = getDropTypeLabel({ simple, ft, nft, fc });
+          const type = getDropTypeLabel({ simple, ft, nft, fc });
 
-            let nftHref = '';
-            if (type === 'NFT') {
-              const fcMethod = (fc as ProtocolReturnedFCData).methods[0]?.[0];
-              const { receiver_id } = fcMethod as ProtocolReturnedMethod;
+          let nftHref = '';
+          if (type === 'NFT') {
+            const fcMethod = (fc as ProtocolReturnedFCData).methods[0]?.[0];
+            const { receiver_id } = fcMethod as ProtocolReturnedMethod;
 
-              const nftData = await asyncWithTimeout(
-                viewCall({
-                  contractId: receiver_id,
-                  methodName: FETCH_NFT_METHOD_NAME,
-                  args: {
-                    mint_id: parseInt(id),
-                  },
-                }),
-              ).catch((_) => {
-                console.error(); // eslint-disable-line no-console
-              });
+            const nftData = await asyncWithTimeout(
+              viewCall({
+                contractId: receiver_id,
+                methodName: FETCH_NFT_METHOD_NAME,
+                args: {
+                  mint_id: parseInt(id),
+                },
+              }),
+            ).catch((_) => {
+              console.error(); // eslint-disable-line no-console
+            });
 
-              nftHref =
-                `${getConfig().cloudflareIfps}/${nftData?.metadata?.media as string}` ??
-                'https://placekitten.com/200/300';
-            }
+            nftHref =
+              `${getConfig().cloudflareIfps as string}/${nftData?.metadata?.media as string}` ??
+              'https://placekitten.com/200/300';
+          }
 
-            return {
-              id,
-              name: truncateAddress(meta.dropName, 'end', 48),
-              type,
-              media: type === 'NFT' ? nftHref : undefined,
-              claimed: `${
-                next_key_id - (await getKeySupplyForDrop({ dropId: id }))
-              } / ${next_key_id}`,
-            };
-          },
-        ),
+          return {
+            id,
+            name: truncateAddress(meta.dropName, 'end', 48),
+            type,
+            media: type === 'NFT' ? nftHref : undefined,
+            claimed: `${
+              next_key_id - (await getKeySupplyForDrop({ dropId: id }))
+            } / ${next_key_id}`,
+          };
+        }),
       ),
     );
 

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -7,6 +7,7 @@ import {
   getDropInformation,
   getKeyInformationBatch,
   getKeySupplyForDrop,
+  type ProtocolReturnedDrop,
 } from 'keypom-js';
 
 import { CopyIcon, DeleteIcon } from '@/components/Icons';
@@ -35,7 +36,7 @@ export default function NFTDropManagerPage() {
   const { id: dropId } = useParams();
   const [loading, setLoading] = useState(true);
 
-  const [name, setName] = useState('Drop');
+  const [name, setName] = useState('Untitled');
   const [dataSize, setDataSize] = useState<number>(0);
   const [claimed, setClaimed] = useState<number>(0);
   const [data, setData] = useState<DataItem[]>([INITIAL_SAMPLE_DATA[0]]);
@@ -107,7 +108,8 @@ export default function NFTDropManagerPage() {
     setDataSize(drop.next_key_id);
     setClaimed(await getKeySupplyForDrop({ dropId }));
 
-    setName(JSON.parse(drop.metadata as unknown as string).dropName);
+    const metadata = JSON.parse(((drop as ProtocolReturnedDrop).metadata as string) || '{}');
+    if (metadata.dropName) setName(metadata.dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({
       numKeys:

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -21,6 +21,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import getConfig from '@/config/config';
 import { useValidMasterKey } from '@/hooks/useValidMasterKey';
 import { share } from '@/utils/share';
+import keypomInstance from '@/lib/keypom';
 
 import { tableColumns } from '../../components/TableColumn';
 import { INITIAL_SAMPLE_DATA } from '../../constants/common';
@@ -108,7 +109,9 @@ export default function NFTDropManagerPage() {
     setDataSize(drop.next_key_id);
     setClaimed(await getKeySupplyForDrop({ dropId }));
 
-    const metadata = JSON.parse(((drop as ProtocolReturnedDrop).metadata as string) || '{}');
+    const metadata = await keypomInstance.getDropMetadata(
+      (drop as ProtocolReturnedDrop).metadata as string,
+    );
     if (metadata.dropName) setName(metadata.dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -109,10 +109,10 @@ export default function NFTDropManagerPage() {
     setDataSize(drop.next_key_id);
     setClaimed(await getKeySupplyForDrop({ dropId }));
 
-    const metadata = await keypomInstance.getDropMetadata(
+    const { dropName } = await keypomInstance.getDropMetadata(
       (drop as ProtocolReturnedDrop).metadata as string,
     );
-    if (metadata.dropName) setName(metadata.dropName);
+    setName(dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({
       numKeys:

--- a/src/features/drop-manager/routes/ticket/[id].tsx
+++ b/src/features/drop-manager/routes/ticket/[id].tsx
@@ -22,6 +22,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import getConfig from '@/config/config';
 import { useValidMasterKey } from '@/hooks/useValidMasterKey';
 import { share } from '@/utils/share';
+import keypomInstance from '@/lib/keypom';
 
 import { getClaimStatus } from '../../utils/getClaimStatus';
 import { getBadgeType } from '../../utils/getBadgeType';
@@ -150,7 +151,9 @@ export default function TicketDropManagerPage() {
 
     setDataSize(drop.next_key_id);
 
-    const metadata = JSON.parse(((drop as ProtocolReturnedDrop).metadata as string) || '{}');
+    const metadata = await keypomInstance.getDropMetadata(
+      (drop as ProtocolReturnedDrop).metadata as string,
+    );
     if (metadata.dropName) setName(metadata.dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({

--- a/src/features/drop-manager/routes/ticket/[id].tsx
+++ b/src/features/drop-manager/routes/ticket/[id].tsx
@@ -8,6 +8,7 @@ import {
   getKeyInformationBatch,
   getKeysForDrop,
   getKeySupplyForDrop,
+  type ProtocolReturnedDrop,
 } from 'keypom-js';
 
 import { CopyIcon, DeleteIcon } from '@/components/Icons';
@@ -39,7 +40,7 @@ export default function TicketDropManagerPage() {
   const { id: dropId } = useParams();
   const [loading, setLoading] = useState(true);
 
-  const [name, setName] = useState('Drop');
+  const [name, setName] = useState('Untitled');
   const [dataSize, setDataSize] = useState<number>(0);
   const [claimed, setClaimed] = useState<number>(0);
   const [data, setData] = useState<DataItem[]>([INITIAL_SAMPLE_DATA[1]]);
@@ -149,7 +150,8 @@ export default function TicketDropManagerPage() {
 
     setDataSize(drop.next_key_id);
 
-    setName(JSON.parse(drop.metadata as unknown as string).dropName);
+    const metadata = JSON.parse(((drop as ProtocolReturnedDrop).metadata as string) || '{}');
+    if (metadata.dropName) setName(metadata.dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({
       numKeys:

--- a/src/features/drop-manager/routes/ticket/[id].tsx
+++ b/src/features/drop-manager/routes/ticket/[id].tsx
@@ -151,10 +151,10 @@ export default function TicketDropManagerPage() {
 
     setDataSize(drop.next_key_id);
 
-    const metadata = await keypomInstance.getDropMetadata(
+    const { dropName } = await keypomInstance.getDropMetadata(
       (drop as ProtocolReturnedDrop).metadata as string,
     );
-    if (metadata.dropName) setName(metadata.dropName);
+    setName(dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({
       numKeys:

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -21,6 +21,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import getConfig from '@/config/config';
 import { useValidMasterKey } from '@/hooks/useValidMasterKey';
 import { share } from '@/utils/share';
+import keypomInstance from '@/lib/keypom';
 
 import { tableColumns } from '../../components/TableColumn';
 import { INITIAL_SAMPLE_DATA } from '../../constants/common';
@@ -109,7 +110,9 @@ export default function TokenDropManagerPage() {
     setDataSize(drop.next_key_id);
     setClaimed(await getKeySupplyForDrop({ dropId }));
 
-    const metadata = JSON.parse(((drop as ProtocolReturnedDrop).metadata as string) || '{}');
+    const metadata = await keypomInstance.getDropMetadata(
+      (drop as ProtocolReturnedDrop).metadata as string,
+    );
     if (metadata.dropName) setName(metadata.dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -110,10 +110,10 @@ export default function TokenDropManagerPage() {
     setDataSize(drop.next_key_id);
     setClaimed(await getKeySupplyForDrop({ dropId }));
 
-    const metadata = await keypomInstance.getDropMetadata(
+    const { dropName } = await keypomInstance.getDropMetadata(
       (drop as ProtocolReturnedDrop).metadata as string,
     );
-    if (metadata.dropName) setName(metadata.dropName);
+    setName(dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({
       numKeys:

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -7,6 +7,7 @@ import {
   getKeyInformationBatch,
   deleteKeys,
   getKeySupplyForDrop,
+  type ProtocolReturnedDrop,
 } from 'keypom-js';
 
 import { useAuthWalletContext } from '@/contexts/AuthWalletContext';
@@ -35,7 +36,7 @@ export default function TokenDropManagerPage() {
   const { id: dropId } = useParams();
   const [loading, setLoading] = useState(true);
 
-  const [name, setName] = useState('Drop');
+  const [name, setName] = useState('Untitled');
   const [dataSize, setDataSize] = useState<number>(0);
   const [claimed, setClaimed] = useState<number>(0);
   const [data, setData] = useState<DataItem[]>([INITIAL_SAMPLE_DATA[0]]);
@@ -108,9 +109,8 @@ export default function TokenDropManagerPage() {
     setDataSize(drop.next_key_id);
     setClaimed(await getKeySupplyForDrop({ dropId }));
 
-    const metadata = JSON.parse(drop.metadata as unknown as string);
-
-    setName(metadata.dropName);
+    const metadata = JSON.parse(((drop as ProtocolReturnedDrop).metadata as string) || '{}');
+    if (metadata.dropName) setName(metadata.dropName);
 
     const { publicKeys, secretKeys } = await generateKeys({
       numKeys:

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -179,7 +179,8 @@ class KeypomJS {
     return null;
   };
 
-  getDropMetadata = (metadata: string) => JSON.parse(metadata || '{}');
+  getDropMetadata = (metadata: string) =>
+    JSON.parse(metadata || JSON.stringify({ dropName: 'Untitled' }));
 
   generateExternalWalletLink = async (
     walletName: string,

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -179,19 +179,7 @@ class KeypomJS {
     return null;
   };
 
-  getDropMetadata = (metadata: string) => {
-    if (metadata === null) {
-      return {};
-    }
-
-    try {
-      return JSON.parse(metadata);
-    } catch (err) {
-      return {
-        title: metadata,
-      };
-    }
-  };
+  getDropMetadata = (metadata: string) => JSON.parse(metadata || '{}');
 
   generateExternalWalletLink = async (
     walletName: string,

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -222,7 +222,7 @@ class KeypomJS {
       throw new Error('Unable to claim. This drop may have been claimed before.');
     }
     console.log(drop);
-    const dropMetadata = drop.metadata !== undefined ? this.getDropMetadata(drop.metadata) : {};
+    const dropMetadata = this.getDropMetadata(drop.metadata);
     let ftMetadata;
     if (drop.ft !== undefined) {
       ftMetadata = await getFTMetadata({ contractId: drop.ft.contract_id });
@@ -252,7 +252,7 @@ class KeypomJS {
       throw new Error('Unable to claim. This drop may have been claimed before.');
     }
 
-    const dropMetadata = drop.metadata !== undefined ? this.getDropMetadata(drop.metadata) : {};
+    const dropMetadata = this.getDropMetadata(drop.metadata);
 
     const fcMethods = drop.fc?.methods;
     if (
@@ -304,7 +304,7 @@ class KeypomJS {
     }
     const remainingUses = await this.checkTicketRemainingUses(contractId, secretKey);
 
-    const dropMetadata = drop.metadata !== undefined ? this.getDropMetadata(drop.metadata) : {};
+    const dropMetadata = this.getDropMetadata(drop.metadata);
 
     const fcMethods = drop.fc?.methods;
     if (


### PR DESCRIPTION
# Description
This PR fixes proper JSON parsing and catching when getting the `dropName` from `drop.metadata`
Fixes #149

# How to test
Show steps to replicate and test the feature/fixes in this PR

`All Drops`
1. Go to `src/features/all-drops/components/AllDrops.tsx` locally
2. add `metadata = undefined;` in line 161
3. `yarn run dev`
4. Open localhost:3000 and connect wallet
5. Go to My Drops
6. all drop name should be reverted to the default `Untitled`

`Drop Manager`
1. Go to `src/features/drop-manager/routes/token/[id].tsx` locally
2. add `drop.metadata = undefined;` in line 111
3. `yarn run dev`
4. Open localhost:3000 and connect wallet
5. Go to My Drops
6. Select any Token drop
7. Drop name should be reverted to the default `Untitled`

# Screenshots/Screen Recording of Implementation
All Drops
![image](https://user-images.githubusercontent.com/40631483/221490682-6b33ad69-d1a5-4687-a5f1-1fae0f787cad.png)

Drop Manager (using Token as reference)
![image](https://user-images.githubusercontent.com/40631483/221490840-3709a3ce-bbf2-4130-8997-bcef5b8e4881.png)
