### PR TITLE
refactor: reuse all keypom calls

### DIFF
--- a/src/features/drop-manager/components/DropManager.tsx
+++ b/src/features/drop-manager/components/DropManager.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Heading, HStack, Stack, type TableProps, Text } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import { deleteDrops, generateKeys, getDropInformation } from 'keypom-js';
 import { useNavigate } from 'react-router-dom';
 
 import { type ColumnItem, type DataItem } from '@/components/Table/types';
@@ -10,9 +9,7 @@ import { NextButton, PrevButton } from '@/components/Pagination';
 import { file } from '@/utils/file';
 import { useAuthWalletContext } from '@/contexts/AuthWalletContext';
 import { useAppContext } from '@/contexts/AppContext';
-import { get } from '@/utils/localStorage';
-import { MASTER_KEY } from '@/constants/common';
-import getConfig from '@/config/config';
+import keypomInstance from '@/lib/keypom';
 
 import { setConfirmationModalHelper } from './ConfirmationModal';
 
@@ -83,19 +80,7 @@ export const DropManager = ({
       setExporting(true);
 
       try {
-        const drop = await getDropInformation({ dropId: data[0].dropId as string });
-        const { secretKeys } = await generateKeys({
-          numKeys: drop.next_key_id,
-          rootEntropy: `${get(MASTER_KEY) as string}-${data[0].dropId as string}`,
-          autoMetaNonceStart: 0,
-        });
-        const links = secretKeys.map(
-          (key, i) =>
-            `${window.location.origin}/claim/${getConfig().contractId}#${key.replace(
-              'ed25519:',
-              '',
-            )}`,
-        );
+        const links = await keypomInstance.getLinksToExport(data[0].dropId as string);
         file(`Drop ID ${data[0].dropId as string}.csv`, links.join('\r\n'));
       } catch (e) {
         console.error('error', e);
@@ -114,7 +99,7 @@ export const DropManager = ({
       setConfirmationModalHelper(
         setAppModal,
         async () => {
-          await deleteDrops({
+          await keypomInstance.deleteDrops({
             wallet,
             dropIds: [dropId as string],
           });

--- a/src/features/drop-manager/components/DropManager.tsx
+++ b/src/features/drop-manager/components/DropManager.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Heading, HStack, Stack, type TableProps, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Stack,
+  type TableProps,
+  Text,
+  Skeleton,
+} from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -128,13 +137,17 @@ export const DropManager = ({
             {/* Drop name */}
             <Stack maxW={{ base: 'full', md: '22.5rem' }}>
               <Text color="gray.800">Drop name</Text>
-              <Heading>{dropName}</Heading>
+              <Skeleton isLoaded={!loading}>
+                <Heading>{dropName}</Heading>
+              </Skeleton>
             </Stack>
 
             {/* Drops claimed */}
             <Stack maxW={{ base: 'full', md: '22.5rem' }}>
               <Text color="gray.800">{claimedHeaderText}</Text>
-              <Heading>{claimedText}</Heading>
+              <Skeleton isLoaded={!loading}>
+                <Heading>{claimedText}</Heading>
+              </Skeleton>
             </Stack>
           </Stack>
           <Text>Track link status and export them to CSV for use in email campaigns here.</Text>

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -1,25 +1,18 @@
 import { Badge, Box, Button, Text, useToast } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  deleteKeys,
-  generateKeys,
-  getDropInformation,
-  getKeyInformationBatch,
-  getKeySupplyForDrop,
-} from 'keypom-js';
 
 import { CopyIcon, DeleteIcon } from '@/components/Icons';
 import { DropManager } from '@/features/drop-manager/components/DropManager';
 import { useAuthWalletContext } from '@/contexts/AuthWalletContext';
-import { get } from '@/utils/localStorage';
-import { MASTER_KEY, PAGE_SIZE_LIMIT } from '@/constants/common';
+import { PAGE_SIZE_LIMIT } from '@/constants/common';
 import { usePagination } from '@/hooks/usePagination';
 import { type DataItem } from '@/components/Table/types';
 import { useAppContext } from '@/contexts/AppContext';
 import getConfig from '@/config/config';
 import { useValidMasterKey } from '@/hooks/useValidMasterKey';
 import { share } from '@/utils/share';
+import keypomInstance from '@/lib/keypom';
 
 import { tableColumns } from '../../components/TableColumn';
 import { INITIAL_SAMPLE_DATA } from '../../constants/common';
@@ -93,34 +86,16 @@ export default function NFTDropManagerPage() {
 
   const handleGetDrops = async ({ pageIndex = 0, pageSize = PAGE_SIZE_LIMIT }) => {
     if (!accountId) return;
-    let drop = await getDropInformation({
-      dropId,
-    }).catch((_) => {
-      setMissingDropModal(setAppModal);
-      navigate('/drops');
-    });
-    if (!drop)
-      drop = {
-        metadata: '{}',
-      };
 
-    setDataSize(drop.next_key_id);
-    setClaimed(await getKeySupplyForDrop({ dropId }));
+    const { dropSize, dropName, publicKeys, secretKeys, keyInfo } =
+      await keypomInstance.getKeysInfo(dropId as string, pageIndex, pageSize, () => {
+        setMissingDropModal(setAppModal); // User will be redirected if getDropInformation fails
+        navigate('/drops');
+      });
 
-    setName(JSON.parse(drop.metadata as unknown as string).dropName);
-
-    const { publicKeys, secretKeys } = await generateKeys({
-      numKeys:
-        (pageIndex + 1) * pageSize > drop.next_key_id
-          ? drop.next_key_id - pageIndex * pageSize
-          : Math.min(drop.next_key_id, pageSize),
-      rootEntropy: `${get(MASTER_KEY) as string}-${dropId}`,
-      autoMetaNonceStart: pageIndex * pageSize,
-    });
-    const keyInfo = await getKeyInformationBatch({
-      publicKeys,
-      secretKeys,
-    });
+    setDataSize(dropSize);
+    setClaimed(await keypomInstance.getClaimedDropInfo(dropId as string));
+    setName(dropName);
 
     setData(
       secretKeys.map((key, i) => ({
@@ -152,7 +127,7 @@ export default function NFTDropManagerPage() {
     setConfirmationModalHelper(
       setAppModal,
       async () => {
-        await deleteKeys({
+        await keypomInstance.deleteKeys({
           wallet,
           dropId,
           publicKeys: pubKey,

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -25,7 +25,7 @@ export default function TokenDropManagerPage() {
   const { setAppModal } = useAppContext();
   const toast = useToast();
 
-  const { id: dropId } = useParams();
+  const { id: dropId = '' } = useParams();
   const [loading, setLoading] = useState(true);
 
   const [name, setName] = useState('Untitled');
@@ -37,14 +37,26 @@ export default function TokenDropManagerPage() {
   const { selector, accountId } = useAuthWalletContext();
 
   useEffect(() => {
-    if (selector === null) return;
-    const getWallet = async () => {
-      setWallet(await selector.wallet());
-    };
+    if (dropId === '') navigate('/drops');
+  }, [dropId]);
+
+  const getWallet = async () => {
+    if (selector === null) {
+      return;
+    }
+    try {
+      const selectorWallet = await selector?.wallet();
+      setWallet(selectorWallet);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
     getWallet();
   }, [selector]);
 
-  const { masterKeyValidity } = useValidMasterKey({ dropId: dropId as string });
+  const { masterKeyValidity } = useValidMasterKey({ dropId });
   useEffect(() => {
     if (!masterKeyValidity) {
       setMasterKeyValidityModal(
@@ -84,19 +96,22 @@ export default function TokenDropManagerPage() {
   });
 
   const handleGetDrops = async ({ pageIndex = 0, pageSize = PAGE_SIZE_LIMIT }) => {
-    if (!accountId) return null;
-    const { dropSize, dropName, publicKeys, secretKeys, keyInfo } =
-      await keypomInstance.getKeysInfo(dropId as string, pageIndex, pageSize, () => {
-        setMissingDropModal(setAppModal); // User will be redirected if getDropInformation fails
-        navigate('/drops');
-      });
-
+    if (!accountId) return;
+    const keyInfoReturn = await keypomInstance.getKeysInfo(dropId, pageIndex, pageSize, () => {
+      setMissingDropModal(setAppModal); // User will be redirected if getDropInformation fails
+      navigate('/drops');
+    });
+    if (keyInfoReturn === undefined) {
+      navigate('/drops');
+      return;
+    }
+    const { dropSize, dropName, publicKeys, secretKeys, keyInfo } = keyInfoReturn;
     setDataSize(dropSize);
-    setClaimed(await keypomInstance.getClaimedDropInfo(dropId as string));
+    setClaimed(await keypomInstance.getClaimedDropInfo(dropId));
     setName(dropName);
 
     setData(
-      secretKeys.map((key, i) => ({
+      secretKeys.map((key: string, i) => ({
         id: i,
         publicKey: publicKeys[i],
         link: `${window.location.origin}/claim/${getConfig().contractId}#${key.replace(

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -16,6 +16,7 @@ import {
   getKeySupplyForDrop,
   deleteKeys,
   getKeysForDrop,
+  deleteDrops,
 } from 'keypom-js';
 import * as nearAPI from 'near-api-js';
 
@@ -197,6 +198,8 @@ class KeypomJS {
   getDropMetadata = (metadata: string) =>
     JSON.parse(metadata || JSON.stringify({ dropName: 'Untitled' }));
 
+  deleteDrops = async ({ wallet, dropIds }) => await deleteDrops({ wallet, dropIds });
+
   deleteKeys = async ({ wallet, dropId, publicKeys }) =>
     await deleteKeys({ wallet, dropId, publicKeys });
 
@@ -210,6 +213,22 @@ class KeypomJS {
 
   getKeysForDrop = async ({ dropId, limit, start }) =>
     await getKeysForDrop({ dropId, limit, start });
+
+  getLinksToExport = async (dropId) => {
+    const drop = await this.getDropInfo(dropId);
+    const { secretKeys } = await generateKeys({
+      numKeys: drop.next_key_id,
+      rootEntropy: `${get(MASTER_KEY) as string}-${dropId as string}`,
+      autoMetaNonceStart: 0,
+    });
+
+    const links = secretKeys.map(
+      (key, i) =>
+        `${window.location.origin}/claim/${getConfig().contractId}#${key.replace('ed25519:', '')}`,
+    );
+
+    return links;
+  };
 
   getKeysInfo = async (
     dropId: string,


### PR DESCRIPTION
# Description
This PR:
- refactors all `keypom-js` functions from `All Drops` `[id]`s and `Drop Manager`.

Fixes #148

# How to test
Show steps to replicate and test the feature/fixes in this PR

1. Go to `My Drops`
2. Ensure that `All Drops` drops can still paginate and load properly
3. Go to any drop
4. Ensure that all key still visible and can paginate properly
5. Ensure that claimed number still load properly
6. Ensure that `Cancel All` still works
7. Ensure that `Export .CSV` still works.

# Screenshots/Screen Recording of Implementation
