### PR TITLE
hotfix: pagination logic

### DIFF
--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -120,8 +120,8 @@ export default function AllDrops() {
   const {
     hasPagination,
     pagination,
-    firstPage,
-    lastPage,
+    isFirstPage,
+    isLastPage,
     loading,
     handleNextPage,
     handlePrevPage,
@@ -268,7 +268,7 @@ export default function AllDrops() {
           {hasPagination && (
             <PrevButton
               id="all-drops"
-              isDisabled={!!firstPage}
+              isDisabled={!!isFirstPage}
               isLoading={loading.previous}
               onClick={handlePrevPage}
             />
@@ -308,7 +308,7 @@ export default function AllDrops() {
           {hasPagination && (
             <NextButton
               id="all-drops"
-              isDisabled={!!lastPage}
+              isDisabled={!!isLastPage}
               isLoading={loading.next}
               onClick={handleNextPage}
             />

--- a/src/features/drop-manager/components/DropManager.tsx
+++ b/src/features/drop-manager/components/DropManager.tsx
@@ -30,8 +30,8 @@ interface DropManagerProps {
       previous: boolean;
       next: boolean;
     };
-    firstPage: boolean;
-    lastPage: boolean;
+    isFirstPage: boolean;
+    isLastPage: boolean;
     handlePrevPage: () => void;
     handleNextPage: () => void;
   };
@@ -160,7 +160,7 @@ export const DropManager = ({
           {pagination?.hasPagination && (
             <PrevButton
               id={pagination.id}
-              isDisabled={!!pagination.firstPage}
+              isDisabled={!!pagination.isFirstPage}
               isLoading={pagination.paginationLoading.previous}
               onClick={pagination.handlePrevPage}
             />
@@ -184,7 +184,7 @@ export const DropManager = ({
           {pagination?.hasPagination && (
             <NextButton
               id={pagination.id}
-              isDisabled={!!pagination.lastPage}
+              isDisabled={!!pagination.isLastPage}
               isLoading={pagination.paginationLoading.next}
               onClick={pagination.handleNextPage}
             />

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -72,8 +72,8 @@ export default function NFTDropManagerPage() {
   const {
     hasPagination,
     pagination,
-    firstPage,
-    lastPage,
+    isFirstPage,
+    isLastPage,
     loading: paginationLoading,
     handleNextPage,
     handlePrevPage,
@@ -231,8 +231,8 @@ export default function NFTDropManagerPage() {
             hasPagination,
             id: 'token',
             paginationLoading,
-            firstPage,
-            lastPage,
+            isFirstPage,
+            isLastPage,
             handleNextPage,
             handlePrevPage,
           }}

--- a/src/features/drop-manager/routes/ticket/[id].tsx
+++ b/src/features/drop-manager/routes/ticket/[id].tsx
@@ -115,8 +115,8 @@ export default function TicketDropManagerPage() {
   const {
     hasPagination,
     pagination,
-    firstPage,
-    lastPage,
+    isFirstPage,
+    isLastPage,
     loading: paginationLoading,
     handleNextPage,
     handlePrevPage,
@@ -269,8 +269,8 @@ export default function TicketDropManagerPage() {
             hasPagination,
             id: 'token',
             paginationLoading,
-            firstPage,
-            lastPage,
+            isFirstPage,
+            isLastPage,
             handleNextPage,
             handlePrevPage,
           }}

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -71,8 +71,8 @@ export default function TokenDropManagerPage() {
   const {
     hasPagination,
     pagination,
-    firstPage,
-    lastPage,
+    isFirstPage,
+    isLastPage,
     loading: paginationLoading,
     handleNextPage,
     handlePrevPage,
@@ -232,8 +232,8 @@ export default function TokenDropManagerPage() {
             hasPagination,
             id: 'token',
             paginationLoading,
-            firstPage,
-            lastPage,
+            isFirstPage,
+            isLastPage,
             handleNextPage,
             handlePrevPage,
           }}

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { type Pagination } from '@/components/Table/types';
 import { PAGE_SIZE_LIMIT } from '@/constants/common';

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -32,11 +32,11 @@ export const usePagination = ({
   );
 
   const hasPagination = pagination?.pageSize < dataSize;
-  const firstPage = pageIndex === 0;
-  const lastPage = pagination?.pageSize * (pageIndex + 1) >= dataSize;
+  const isFirstPage = pageIndex === 0;
+  const isLastPage = pagination?.pageSize * (pageIndex + 1) >= dataSize;
 
   const handleNextPage = async () => {
-    if (lastPage) return;
+    if (isLastPage) return;
     setIsLoading((prev) => ({ ...prev, next: true }));
     if (handleNextApiCall) {
       await handleNextApiCall();
@@ -49,7 +49,7 @@ export const usePagination = ({
   };
 
   const handlePrevPage = async () => {
-    if (firstPage) return;
+    if (isFirstPage) return;
     setIsLoading((prev) => ({ ...prev, previous: true }));
     if (handlePrevApiCall) {
       await handlePrevApiCall();
@@ -64,8 +64,8 @@ export const usePagination = ({
   return {
     hasPagination,
     pagination: { pageIndex, pageSize },
-    firstPage,
-    lastPage,
+    isFirstPage,
+    isLastPage,
     loading: { previous, next },
     handleNextPage,
     handlePrevPage,

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { type Pagination } from '@/components/Table/types';
 import { PAGE_SIZE_LIMIT } from '@/constants/common';
@@ -33,7 +33,7 @@ export const usePagination = ({
 
   const hasPagination = pagination?.pageSize < dataSize;
   const firstPage = pageIndex === 0;
-  const lastPage = pagination?.pageSize * (pageIndex + 1) > dataSize;
+  const lastPage = pagination?.pageSize * (pageIndex + 1) >= dataSize;
 
   const handleNextPage = async () => {
     if (lastPage) return;


### PR DESCRIPTION
# Description
This PR fixes pagination logic where there's an additional page for any drops/keys with multiple of 10s 

Fixes # (issue)

# How to test
Show steps to replicate and test the feature/fixes in this PR

1. go to `All Drops`
2. select a drop with keys that are in multiple of 10s
3. paginate to the last page

# Screenshots/Screen Recording of Implementation

https://user-images.githubusercontent.com/40631483/221598882-49081dcc-26fe-41c8-a2ae-8abc689ed2d0.mov

