### PR TITLE
chore: update modal look

### DIFF
--- a/src/components/AppModal/AppModal.tsx
+++ b/src/components/AppModal/AppModal.tsx
@@ -13,6 +13,7 @@ import {
   Center,
   Spinner,
   Text,
+  ModalCloseButton,
 } from '@chakra-ui/react';
 import { CheckIcon, CloseIcon } from '@chakra-ui/icons';
 
@@ -49,6 +50,7 @@ export const AppModal = () => {
         >
           {appModal.header && <h4>{appModal.header}</h4>}
         </ModalHeader>
+        {appModal.closeButtonVisible && <ModalCloseButton />}
         <ModalBody>
           {appModal.isLoading && (
             <Center>
@@ -98,7 +100,7 @@ export const AppModal = () => {
 
         {appModal.options && appModal.options.length > 0 && (
           <ModalFooter>
-            <ButtonGroup>
+            <ButtonGroup justifyContent="center" w="full">
               {appModal.options.map(({ label, func, buttonProps, lazy }, i) => (
                 <Button
                   key={i}

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -18,6 +18,7 @@ export interface AppModalOptions {
 interface AppModalValues {
   isOpen: boolean;
   closeOnOverlayClick?: boolean;
+  closeButtonVisible?: boolean;
   message?: string;
   header?: string;
   options?: AppModalOptions[];

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -19,7 +19,6 @@ import {
   getDrops,
   getKeySupplyForDrop,
   getDropSupplyForOwner,
-  deleteDrops,
   type ProtocolReturnedSimpleData,
   type ProtocolReturnedFTData,
   type ProtocolReturnedNFTData,
@@ -216,7 +215,7 @@ export default function AllDrops() {
 
   const handleDeleteClick = (dropId) => {
     setConfirmationModalHelper(setAppModal, async () => {
-      await deleteDrops({
+      await keypomInstance.deleteDrops({
         wallet,
         dropIds: [dropId],
       });

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -215,18 +215,13 @@ export default function AllDrops() {
   ));
 
   const handleDeleteClick = (dropId) => {
-    setConfirmationModalHelper(
-      setAppModal,
-      async () => {
-        await deleteDrops({
-          wallet,
-          dropIds: [dropId],
-        });
-        handleGetDrops({});
-      },
-      () => null,
-      'key',
-    );
+    setConfirmationModalHelper(setAppModal, async () => {
+      await deleteDrops({
+        wallet,
+        dropIds: [dropId],
+      });
+      handleGetDrops({});
+    });
   };
 
   const getTableRows = (): DataItem[] => {

--- a/src/features/all-drops/components/ConfirmationModal.tsx
+++ b/src/features/all-drops/components/ConfirmationModal.tsx
@@ -1,22 +1,16 @@
-export const setConfirmationModalHelper = (setAppModal, confirm, cancel, buttonProps = {}) => {
+export const setConfirmationModalHelper = (setAppModal, confirm) => {
   setAppModal({
     isOpen: true,
     header: 'Are you sure?',
     message: `You are going to delete the drop.`,
+    closeButtonVisible: true,
     options: [
       {
         label: 'Delete',
         func: async () => {
           if (confirm) await confirm();
         },
-        buttonProps,
-      },
-      {
-        label: 'Cancel',
-        func: () => {
-          if (cancel) cancel();
-        },
-        buttonProps,
+        buttonProps: { width: 'full' },
       },
     ],
   });

--- a/src/features/drop-manager/components/ConfirmationModal.tsx
+++ b/src/features/drop-manager/components/ConfirmationModal.tsx
@@ -1,28 +1,16 @@
-export const setConfirmationModalHelper = (
-  setAppModal,
-  confirm,
-  cancel,
-  type = 'key',
-  buttonProps = {},
-) => {
+export const setConfirmationModalHelper = (setAppModal, confirm, type = 'key') => {
   setAppModal({
     isOpen: true,
     header: 'Are you sure?',
     message: `You are going to delete the ${type === 'key' ? 'key' : 'drop'}.`,
+    closeButtonVisible: true,
     options: [
       {
         label: 'Delete',
         func: async () => {
           if (confirm) await confirm();
         },
-        buttonProps,
-      },
-      {
-        label: 'Cancel',
-        func: () => {
-          if (cancel) cancel();
-        },
-        buttonProps,
+        buttonProps: { width: 'full' },
       },
     ],
   });

--- a/src/features/drop-manager/components/DropManager.tsx
+++ b/src/features/drop-manager/components/DropManager.tsx
@@ -120,7 +120,6 @@ export const DropManager = ({
           });
           navigate('/drops');
         },
-        () => null,
         'drop',
       );
       console.log('deleting drop', dropId);

--- a/src/features/drop-manager/components/DropManager.tsx
+++ b/src/features/drop-manager/components/DropManager.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Heading, HStack, Stack, type TableProps, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Stack,
+  type TableProps,
+  Text,
+  Skeleton,
+} from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { deleteDrops, generateKeys, getDropInformation } from 'keypom-js';
 import { useNavigate } from 'react-router-dom';
@@ -142,13 +151,17 @@ export const DropManager = ({
             {/* Drop name */}
             <Stack maxW={{ base: 'full', md: '22.5rem' }}>
               <Text color="gray.800">Drop name</Text>
-              <Heading>{dropName}</Heading>
+              <Skeleton isLoaded={!loading}>
+                <Heading>{dropName}</Heading>
+              </Skeleton>
             </Stack>
 
             {/* Drops claimed */}
             <Stack maxW={{ base: 'full', md: '22.5rem' }}>
               <Text color="gray.800">{claimedHeaderText}</Text>
-              <Heading>{claimedText}</Heading>
+              <Skeleton isLoaded={!loading}>
+                <Heading>{claimedText}</Heading>
+              </Skeleton>
             </Stack>
           </Stack>
           <Text>Track link status and export them to CSV for use in email campaigns here.</Text>

--- a/src/features/drop-manager/routes/nft/[id].tsx
+++ b/src/features/drop-manager/routes/nft/[id].tsx
@@ -164,7 +164,6 @@ export default function NFTDropManagerPage() {
         });
         window.location.reload();
       },
-      () => null,
       'key',
     );
   };

--- a/src/features/drop-manager/routes/ticket/[id].tsx
+++ b/src/features/drop-manager/routes/ticket/[id].tsx
@@ -207,7 +207,6 @@ export default function TicketDropManagerPage() {
         });
         window.location.reload();
       },
-      () => null,
       'key',
     );
   };

--- a/src/features/drop-manager/routes/token/[id].tsx
+++ b/src/features/drop-manager/routes/token/[id].tsx
@@ -165,7 +165,6 @@ export default function TokenDropManagerPage() {
         });
         window.location.reload();
       },
-      () => null,
       'key',
     );
   };


### PR DESCRIPTION
# Description
This PR:
- modify the look of the modal
- add skeleton on dropName and claimedText in dropmanager

# How to test
Show steps to replicate and test the feature/fixes in this PR
Modals to check:
1. Set Master key modal from the dropdown signing button menu
2. All Drops confirmation modal from clicking the trash button
3. [id].tsx for token/ticket/nft confirmation modal from clicking the trash button
4. [id].tsx for token/ticket/nft confirmation modal from clicking the Cancel All button
5. set master key modal from selecting a drop with wrong master key
6. missing drop modal from attempting to go to a drop with invalid dropId

# Screenshots/Screen Recording of Implementation
1.
![image](https://user-images.githubusercontent.com/40631483/221633446-9162be58-cae7-440f-808b-2dad44b8adbc.png)

2.
![image](https://user-images.githubusercontent.com/40631483/221635679-9a7c6254-a8c5-439b-a098-0012e8bf0b1b.png)

3.
![image](https://user-images.githubusercontent.com/40631483/221635763-32406bb9-f1f7-41a2-9494-76a9c2cc8604.png)

4.
![image](https://user-images.githubusercontent.com/40631483/221635822-9d118ae0-b892-41fc-8607-e7d1cab965f6.png)

5.
![image](https://user-images.githubusercontent.com/40631483/221634052-bdd0d0f3-07ab-47ac-8a9f-ed5484daf1ee.png)

6.
![image](https://user-images.githubusercontent.com/40631483/221635965-de4a4915-a2d1-48f4-b23b-c70552b532c1.png)
