### PR TITLE
Clean console errors in All Drops, Drop managers and Create Drops pages

### DIFF
--- a/src/components/Checkboxes/Checkboxes.tsx
+++ b/src/components/Checkboxes/Checkboxes.tsx
@@ -39,7 +39,6 @@ export const Checkboxes = ({ items = [], defaultValues = [], onChange }: Checkbo
         }
         iconColor="blue.400"
         iconSize="1.375rem"
-        isIndeterminate={true}
         p={{ base: '2', md: '4' }}
         pl={{ base: '3' }}
         value={item.value}

--- a/src/components/Checkboxes/Checkboxes.tsx
+++ b/src/components/Checkboxes/Checkboxes.tsx
@@ -39,6 +39,7 @@ export const Checkboxes = ({ items = [], defaultValues = [], onChange }: Checkbo
         }
         iconColor="blue.400"
         iconSize="1.375rem"
+        isIndeterminate={true}
         p={{ base: '2', md: '4' }}
         pl={{ base: '3' }}
         value={item.value}

--- a/src/components/Icons/CheckedIcon.tsx
+++ b/src/components/Icons/CheckedIcon.tsx
@@ -1,6 +1,10 @@
 import { Icon, type IconProps } from '@chakra-ui/react';
 
-export const CheckedIcon = (props: IconProps) => {
+interface CheckedIconProps extends IconProps {
+  isDeterminate?: boolean;
+}
+
+export const CheckedIcon = (props: CheckedIconProps) => {
   return (
     <Icon
       fill="none"

--- a/src/components/Icons/CheckedIcon.tsx
+++ b/src/components/Icons/CheckedIcon.tsx
@@ -1,10 +1,11 @@
 import { Icon, type IconProps } from '@chakra-ui/react';
 
 interface CheckedIconProps extends IconProps {
-  isDeterminate?: boolean;
+  isIndeterminate?: boolean;
+  isChecked?: boolean;
 }
 
-export const CheckedIcon = (props: CheckedIconProps) => {
+export const CheckedIcon = ({ isIndeterminate, isChecked, ...props }: CheckedIconProps) => {
   return (
     <Icon
       fill="none"

--- a/src/components/Icons/UncheckedIcon.tsx
+++ b/src/components/Icons/UncheckedIcon.tsx
@@ -1,6 +1,10 @@
 import { Icon, type IconProps } from '@chakra-ui/react';
 
-export const UncheckedIcon = (props: IconProps) => {
+interface CheckedIconProps extends IconProps {
+  isDeterminate?: boolean;
+}
+
+export const UncheckedIcon = (props: CheckedIconProps) => {
   return (
     <Icon
       fill="none"

--- a/src/components/Icons/UncheckedIcon.tsx
+++ b/src/components/Icons/UncheckedIcon.tsx
@@ -1,10 +1,11 @@
 import { Icon, type IconProps } from '@chakra-ui/react';
 
 interface CheckedIconProps extends IconProps {
-  isDeterminate?: boolean;
+  isIndeterminate?: boolean;
+  isChecked?: boolean;
 }
 
-export const UncheckedIcon = (props: CheckedIconProps) => {
+export const UncheckedIcon = ({ isIndeterminate, isChecked, ...props }: CheckedIconProps) => {
   return (
     <Icon
       fill="none"

--- a/src/components/Table/DataTable.tsx
+++ b/src/components/Table/DataTable.tsx
@@ -54,8 +54,8 @@ export const DataTable = ({
     if (loading) {
       return Array.from([1, 2, 3]).map((_, index) => (
         <Tr key={index}>
-          {columns.map((column) => (
-            <Td key={`${column.title}-${index}`} {...column.tdProps}>
+          {columns.map((column, colIndex) => (
+            <Td key={`${column.title}-${index}-${colIndex}`} {...column.tdProps}>
               {column.loadingElement}
             </Td>
           ))}
@@ -83,7 +83,7 @@ export const DataTable = ({
         }
       >
         {columns.map((column, i) => (
-          <Td key={`${column.title}-${drop.id}-${i}`} {...column.tdProps}>
+          <Td key={`${column.id}-${drop.id}-${i}`} {...column.tdProps}>
             {column.selector(drop)}
           </Td>
         ))}
@@ -103,7 +103,7 @@ export const DataTable = ({
                   <Thead>
                     <Tr>
                       {columns.map((col) => (
-                        <Th key={col.title} fontFamily="body" {...col.thProps}>
+                        <Th key={col.id} fontFamily="body" {...col.thProps}>
                           {col.title}
                         </Th>
                       ))}

--- a/src/components/Table/MobileDataTable.tsx
+++ b/src/components/Table/MobileDataTable.tsx
@@ -32,8 +32,8 @@ export const MobileDataTable = ({
     if (loading) {
       return Array.from([1, 2, 3]).map((_, index) => (
         <Tr key={index}>
-          {columns.map((column) => (
-            <Td key={`${column.title}-${index}`} {...column.tdProps}>
+          {columns.map((column, colIndex) => (
+            <Td key={`${column.id}-${index}-${colIndex}`} {...column.tdProps}>
               {column.loadingElement}
             </Td>
           ))}
@@ -65,7 +65,7 @@ export const MobileDataTable = ({
             {columns
               .filter((column) => actionColumn.title !== column.title) // exclude action column
               .map((column) => (
-                <Box key={`${drop.id}-${column.title}`}>{column.selector(drop)}</Box>
+                <Box key={`${drop.id}-${column.id}`}>{column.selector(drop)}</Box>
               ))}
           </VStack>
         </Td>

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -8,6 +8,7 @@ export interface DataItem {
 }
 
 export interface ColumnItem {
+  id: string; // unique key
   title: string;
   selector: (arg: DataItem) => React.ReactNode | Primitive;
   loadingElement?: React.ReactNode;

--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -48,6 +48,7 @@ const FETCH_NFT_METHOD_NAME = 'get_series_info';
 
 const COLUMNS: ColumnItem[] = [
   {
+    id: 'dropName',
     title: 'Drop name',
     selector: (drop) => drop.name,
     thProps: {
@@ -56,21 +57,25 @@ const COLUMNS: ColumnItem[] = [
     loadingElement: <Skeleton height="30px" />,
   },
   {
+    id: 'media',
     title: '',
     selector: (drop) => drop.media,
     loadingElement: <Skeleton height="30px" />,
   },
   {
+    id: 'dropType',
     title: 'Drop type',
     selector: (drop) => drop.type,
     loadingElement: <Skeleton height="30px" />,
   },
   {
+    id: 'claimStatus',
     title: 'Claimed',
     selector: (drop) => drop.claimed,
     loadingElement: <Skeleton height="30px" />,
   },
   {
+    id: 'action',
     title: '',
     selector: (drop) => drop.action,
     tdProps: {

--- a/src/features/create-drop/components/Fields/ArtworkInput.tsx
+++ b/src/features/create-drop/components/Fields/ArtworkInput.tsx
@@ -45,7 +45,7 @@ export const ArtworkInput = ({ name = FIELD_NAME }: ArtworkInputProps) => {
       control={control}
       name={name}
       render={(
-        { field: { onChange, value, ...props }, fieldState: { error } }, // value is unused to prevent `onChange` from updating it
+        { field: { onChange, value, ref, ...props }, fieldState: { error } }, // value is unused to prevent `onChange` from updating it
       ) => {
         if (value === null) {
           setSelectedFile(undefined);

--- a/src/features/create-drop/components/nft/Fields/DescriptionInput.tsx
+++ b/src/features/create-drop/components/nft/Fields/DescriptionInput.tsx
@@ -14,13 +14,13 @@ export const DescriptionInput = ({ control }: DescriptionProps) => {
     <Controller
       control={control}
       name={FIELD_NAME}
-      render={({ field, fieldState: { error } }) => (
+      render={({ field: { ref, ...fieldProps }, fieldState: { error } }) => (
         <TextAreaInput
           errorMessage={error?.message}
           isInvalid={!!error?.message}
           label="Description"
           placeholder="A commemorative NFT for attending the Vandelay Industries networking event."
-          {...field}
+          {...fieldProps}
         />
       )}
     />

--- a/src/features/create-drop/components/nft/Fields/NftNameInput.tsx
+++ b/src/features/create-drop/components/nft/Fields/NftNameInput.tsx
@@ -15,13 +15,13 @@ export const NftNameInput = ({ control }: NftNameInputProps) => {
     <Controller
       control={control}
       name={FIELD_NAME}
-      render={({ field, fieldState: { error } }) => (
+      render={({ field: { ref, ...fieldProps }, fieldState: { error } }) => (
         <TextInput
           errorMessage={error?.message}
           isInvalid={!!error?.message}
           label="Name"
           placeholder="Art Vandelay Official"
-          {...field}
+          {...fieldProps}
         />
       )}
     />

--- a/src/features/create-drop/components/nft/Fields/NumberInput.tsx
+++ b/src/features/create-drop/components/nft/Fields/NumberInput.tsx
@@ -15,12 +15,13 @@ export const NumberInput = ({ control }: NumberInputProps) => {
     <Controller
       control={control}
       name={FIELD_NAME}
-      render={({ field: { ref, ...fieldProps }, fieldState: { error } }) => (
+      render={({ field: { ref, value, ...fieldProps }, fieldState: { error } }) => (
         <TextInput
           errorMessage={error?.message}
           isInvalid={!!error?.message}
           label="Number"
           type="number"
+          value={value || ''}
           {...fieldProps}
         />
       )}

--- a/src/features/create-drop/components/nft/Fields/NumberInput.tsx
+++ b/src/features/create-drop/components/nft/Fields/NumberInput.tsx
@@ -15,14 +15,13 @@ export const NumberInput = ({ control }: NumberInputProps) => {
     <Controller
       control={control}
       name={FIELD_NAME}
-      render={({ field, fieldState: { error } }) => (
+      render={({ field: { ref, ...fieldProps }, fieldState: { error } }) => (
         <TextInput
-          defaultValue={1}
           errorMessage={error?.message}
           isInvalid={!!error?.message}
           label="Number"
           type="number"
-          {...field}
+          {...fieldProps}
         />
       )}
     />

--- a/src/features/create-drop/components/token/CreateTokenDropForm.tsx
+++ b/src/features/create-drop/components/token/CreateTokenDropForm.tsx
@@ -121,19 +121,22 @@ export const CreateTokenDropForm = () => {
         <Controller
           control={control}
           name="totalLinks"
-          render={({ field, fieldState: { error } }) => (
-            <FormControl errorText={error?.message} label="Number of links">
-              <Input
-                isInvalid={Boolean(error?.message)}
-                placeholder="1 - 50"
-                type="number"
-                {...field}
-                onChange={(e) => {
-                  field.onChange(parseInt(e.target.value));
-                }}
-              />
-            </FormControl>
-          )}
+          render={({ field: { value, onChange, ...fieldProps }, fieldState: { error } }) => {
+            return (
+              <FormControl errorText={error?.message} label="Number of links">
+                <Input
+                  isInvalid={Boolean(error?.message)}
+                  placeholder="1 - 50"
+                  type="number"
+                  value={value || ''}
+                  onChange={(e) => {
+                    onChange(parseInt(e.target.value));
+                  }}
+                  {...fieldProps}
+                />
+              </FormControl>
+            );
+          }}
         />
 
         <Controller

--- a/src/features/create-drop/components/token/CreateTokenDropForm.tsx
+++ b/src/features/create-drop/components/token/CreateTokenDropForm.tsx
@@ -139,16 +139,17 @@ export const CreateTokenDropForm = () => {
         <Controller
           control={control}
           name="amountPerLink"
-          render={({ field, fieldState: { error } }) => (
+          render={({ field: { value, onChange, name }, fieldState: { error } }) => (
             <FormControl errorText={error?.message} label="Amount per link">
               <WalletBalanceInput
-                {...field}
                 isInvalid={Boolean(error?.message)}
                 maxLength={14}
+                name={name}
+                value={value}
                 onChange={(e) => {
                   if (e.target.value.length > e.target.maxLength)
                     e.target.value = e.target.value.slice(0, e.target.maxLength);
-                  field.onChange(parseFloat(e.target.value));
+                  onChange(parseFloat(e.target.value));
                 }}
               >
                 <WalletBalanceInput.TokenMenu
@@ -176,7 +177,7 @@ export const CreateTokenDropForm = () => {
               label="Wallets"
             >
               <Checkboxes
-                defaultValues={['my_near_wallet']}
+                defaultValues={['mynearwallet']}
                 items={WALLET_OPTIONS}
                 onChange={handleCheckboxChange}
               />

--- a/src/features/drop-manager/components/TableColumn.tsx
+++ b/src/features/drop-manager/components/TableColumn.tsx
@@ -3,13 +3,20 @@ import { Skeleton } from '@chakra-ui/react';
 import { type ColumnItem } from '@/components/Table/types';
 
 export const tableColumns: ColumnItem[] = [
-  { title: 'Link', selector: (row) => row.link, loadingElement: <Skeleton height="30px" /> },
   {
+    id: 'title',
+    title: 'Link',
+    selector: (row) => row.link,
+    loadingElement: <Skeleton height="30px" />,
+  },
+  {
+    id: 'claimStatus',
     title: 'Claim Status',
     selector: (row) => row.hasClaimed,
     loadingElement: <Skeleton height="30px" />,
   },
   {
+    id: 'action',
     title: 'Action',
     selector: (row) => row.action,
     tdProps: {


### PR DESCRIPTION
# Description
Clean up console warnings/errors in All Drops, Drop managers and Create Drops pages

Some warnings fixes were
Drops pages:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/19740800/222197479-4e27dd6c-6688-463a-82e1-c94ae3c2b393.png">

Create drops:
<img width="385" alt="image" src="https://user-images.githubusercontent.com/19740800/222197572-a765a7c8-b545-48f0-91bb-6cd5428e5f5f.png">
<img width="393" alt="image" src="https://user-images.githubusercontent.com/19740800/222197670-e1c33d81-66d0-4347-9d53-1e4317c59437.png">


Fixes #142 and #141 

# How to test
Show steps to replicate and test the feature/fixes in this PR

1. check out locally, and go to http://localhost:3000/drops
2. check for console errors
3. go to http://localhost:3000/drop/token/new and check
4. go to http://localhost:3000/drop/nft/new and check

# Screenshots/Screen Recording of Implementation
