### PR TITLE
hotfix: hide drop if type is unexpected

### DIFF
--- a/src/features/all-drops/components/AllDrops.tsx
+++ b/src/features/all-drops/components/AllDrops.tsx
@@ -132,10 +132,11 @@ export default function AllDrops() {
 
     let type: string | null = '';
     try {
-      type = keypomInstance.getDropType(drop) || '';
+      type = keypomInstance.getDropType(drop);
     } catch (_) {
       return null;
     }
+    if (type === undefined || type === null || type === '') return null; // don't show the drop if the type return is unexpected
 
     let nftHref = '';
     if (type === DROP_TYPE.NFT) {


### PR DESCRIPTION
# Description
This PR will make any drop with unexpected `type` to not be visible in `AllDrops`

<img width="484" alt="image" src="https://user-images.githubusercontent.com/40631483/223012330-2788b2c4-299f-471b-910a-523b751fa221.png">

https://airfoilhq.slack.com/archives/C04DA26740K/p1678061084631359
