### PR TITLE
hotfix: wrap window.open with setTimeout

### DIFF
--- a/src/features/claim/components/CreateWallet.tsx
+++ b/src/features/claim/components/CreateWallet.tsx
@@ -43,10 +43,12 @@ export const CreateWallet = ({
         }
       }, 20000);
 
-      if (redirectUrl) {
-        return window.open(url + '?redirectUrl=' + redirectUrl, '_blank');
-      }
-      window.open(url, '_blank');
+      window.setTimeout(() => {
+        if (redirectUrl) {
+          return window.open(url + '?redirectUrl=' + redirectUrl, '_blank');
+        }
+        return window.open(url, '_blank');
+      });
     } catch (err) {
       // drop has been claimed
       // refresh to show error


### PR DESCRIPTION
# Description
Fix claim page create a wallet external link not being opened in safari due to security issue

Fixes # (issue)

# How to test
Show steps to replicate and test the feature/fixes in this PR
[hotfix-window-open-blocked-b.keypom-airfoil.pages.dev](https://hotfix-window-open-blocked-b.keypom-airfoil.pages.dev/)

# Screenshots/Screen Recording of Implementation
