### PR TITLE
feat: andrel - 185 general refactors

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "clean": "rm -rf dist .parcel-cache",
     "dev": "yarn clean && yarn static && parcel src/index.html -p 3000",
+    "storybook": "yarn clean && yarn static && IS_STORYBOOK_VIEW=true parcel src/index.html -p 3000",
     "dev-mainnet": "yarn clean && yarn static && REACT_APP_CONTRACT_ID=v2.keypom.near REACT_APP_NETWORK_ID=mainnet parcel src/index.html -p 3000",
     "build": "yarn static && parcel build src/index.html --public-url ./ --no-cache --no-source-maps",
     "build:analyze": "yarn static && parcel build src/index.html --public-url ./ --no-cache --reporter @parcel/reporter-bundle-analyzer",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ChakraProvider } from '@chakra-ui/react';
 
 import { theme } from '@/theme';
 import { router } from '@/router';
+import { router as storybookRouter } from '@/storybook-router';
 import { Loading } from '@/components/Loading';
 
 const Fonts = React.lazy(
@@ -28,15 +29,21 @@ const AppContextProvider = React.lazy(
 );
 
 export const App = () => {
+  const isStorybook = !!process.env.IS_STORYBOOK_VIEW;
+
   return (
     <React.Suspense fallback={<Loading />}>
       <ChakraProvider theme={theme}>
         <Fonts />
-        <AuthWalletContextProvider>
-          <AppContextProvider>
-            <RouterProvider router={router} />
-          </AppContextProvider>
-        </AuthWalletContextProvider>
+        {isStorybook ? (
+          <RouterProvider router={storybookRouter} />
+        ) : (
+          <AuthWalletContextProvider>
+            <AppContextProvider>
+              <RouterProvider router={router} />
+            </AppContextProvider>
+          </AuthWalletContextProvider>
+        )}
       </ChakraProvider>
     </React.Suspense>
   );

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumb, BreadcrumbItem, BreadcrumbLink } from '@chakra-ui/react';
 import { ChevronRightIcon } from '@chakra-ui/icons';
+import { Link } from 'react-router-dom';
 
 export interface IBreadcrumbItem {
   name: string;
@@ -13,7 +14,7 @@ interface BreadcrumbProps {
 export const Breadcrumbs = ({ items }: BreadcrumbProps) => {
   const breadcrumbItems = items.map((item, index) => (
     <BreadcrumbItem key={item.name} color={index === items.length - 1 ? 'gray.800' : 'gray.400'}>
-      <BreadcrumbLink fontSize={{ base: 'sm', md: 'md' }} href={item.href}>
+      <BreadcrumbLink as={Link} fontSize={{ base: 'sm', md: 'md' }} to={item.href}>
         {item.name}
       </BreadcrumbLink>
     </BreadcrumbItem>

--- a/src/features/storybook/components/ButtonStory.tsx
+++ b/src/features/storybook/components/ButtonStory.tsx
@@ -8,7 +8,7 @@ export const ButtonStory = () => {
   const variants = [
     {
       component: <Button w="fit-content"> Primary Button</Button>,
-      label: 'primary (default)',
+      label: 'primary (default) variant',
     },
     {
       component: (
@@ -16,7 +16,7 @@ export const ButtonStory = () => {
           Landing Button
         </Button>
       ),
-      label: 'landing',
+      label: 'landing variant',
     },
     {
       component: (
@@ -24,7 +24,7 @@ export const ButtonStory = () => {
           Secondary Button
         </Button>
       ),
-      label: 'secondary',
+      label: 'secondary variant',
     },
     {
       component: (
@@ -32,7 +32,7 @@ export const ButtonStory = () => {
           Secondary Content Button
         </Button>
       ),
-      label: 'secondary-content-box',
+      label: 'secondary-content-box variant',
     },
     {
       component: (
@@ -40,7 +40,7 @@ export const ButtonStory = () => {
           <AddIcon />
         </Button>
       ),
-      label: 'icon',
+      label: 'icon variant',
     },
     {
       component: (
@@ -48,7 +48,7 @@ export const ButtonStory = () => {
           Pill Button
         </Button>
       ),
-      label: 'pill',
+      label: 'pill variant',
     },
   ];
 
@@ -59,11 +59,11 @@ export const ButtonStory = () => {
           Small Button
         </Button>
       ),
-      label: 'sm',
+      label: 'sm size',
     },
     {
       component: <Button w="fit-content"> Medium Button</Button>,
-      label: 'md (default)',
+      label: 'md (default) size',
     },
   ];
 
@@ -74,7 +74,7 @@ export const ButtonStory = () => {
           Left icon
         </Button>
       ),
-      label: 'With left icon',
+      label: 'leftIcon props',
     },
     {
       component: (
@@ -82,7 +82,7 @@ export const ButtonStory = () => {
           Right icon
         </Button>
       ),
-      label: 'With right icon',
+      label: 'rightIcon props',
     },
     {
       component: (
@@ -90,7 +90,7 @@ export const ButtonStory = () => {
           Token icon
         </Button>
       ),
-      label: 'With ETH token icon',
+      label: 'leftIcon props with TokenIcon',
     },
     {
       component: (
@@ -98,7 +98,7 @@ export const ButtonStory = () => {
           Token icon
         </Button>
       ),
-      label: 'With near icon',
+      label: 'rightIcon props with TokenIcon',
     },
     {
       component: (
@@ -110,7 +110,7 @@ export const ButtonStory = () => {
           Near wallet
         </Button>
       ),
-      label: 'With Near Wallet',
+      label: 'leftIcon props with WalletIcon',
     },
     {
       component: (
@@ -118,7 +118,7 @@ export const ButtonStory = () => {
           Here wallet
         </Button>
       ),
-      label: 'With HERE Wallet',
+      label: 'rightIcon props with WalletIcon',
     },
     {
       component: (
@@ -126,7 +126,7 @@ export const ButtonStory = () => {
           MyNearWallet
         </Button>
       ),
-      label: 'With MyNearWallet',
+      label: 'leftIcon props with WalletIcon',
     },
     {
       component: (
@@ -134,7 +134,7 @@ export const ButtonStory = () => {
           <TokenIcon height="4" symbol="eth" width="4" />
         </Button>
       ),
-      label: 'ETH',
+      label: 'icon variant with ETH symbol',
     },
     {
       component: (
@@ -142,7 +142,7 @@ export const ButtonStory = () => {
           <TokenIcon symbol="near" />
         </Button>
       ),
-      label: 'NEAR',
+      label: 'icon variant with NEAR symbol',
     },
   ];
 
@@ -158,7 +158,7 @@ export const ButtonStory = () => {
           Moon
         </Button>
       ),
-      label: 'With Moon image on the left',
+      label: 'leftIcon props with Moon Image',
     },
     {
       component: (
@@ -171,7 +171,7 @@ export const ButtonStory = () => {
           Moon
         </Button>
       ),
-      label: 'With Moon image on the right',
+      label: 'rightIcon props with Moon Image',
     },
     {
       component: (
@@ -179,7 +179,7 @@ export const ButtonStory = () => {
           <Image alt="keypom-logo" h="6" src={'https://docs.keypom.xyz/img/moon.png'} w="6" />
         </Button>
       ),
-      label: 'Moon',
+      label: 'icon variant with Moon image',
     },
   ];
   return (

--- a/src/features/storybook/components/ButtonStory.tsx
+++ b/src/features/storybook/components/ButtonStory.tsx
@@ -1,0 +1,236 @@
+import { AddIcon } from '@chakra-ui/icons';
+import { Button, Heading, Image, SimpleGrid, Text, VStack } from '@chakra-ui/react';
+
+import { TokenIcon } from '@/components/TokenIcon';
+import { WalletIcon } from '@/components/WalletIcon';
+
+export const ButtonStory = () => {
+  const variants = [
+    {
+      component: <Button w="fit-content"> Primary Button</Button>,
+      label: 'primary (default)',
+    },
+    {
+      component: (
+        <Button variant="landing" w="fit-content">
+          Landing Button
+        </Button>
+      ),
+      label: 'landing',
+    },
+    {
+      component: (
+        <Button variant="secondary" w="fit-content">
+          Secondary Button
+        </Button>
+      ),
+      label: 'secondary',
+    },
+    {
+      component: (
+        <Button variant="secondary-content-box" w="fit-content">
+          Secondary Content Button
+        </Button>
+      ),
+      label: 'secondary-content-box',
+    },
+    {
+      component: (
+        <Button variant="icon" w="fit-content">
+          <AddIcon />
+        </Button>
+      ),
+      label: 'icon',
+    },
+    {
+      component: (
+        <Button variant="pill" w="fit-content">
+          Pill Button
+        </Button>
+      ),
+      label: 'pill',
+    },
+  ];
+
+  const sizes = [
+    {
+      component: (
+        <Button size="sm" w="fit-content">
+          Small Button
+        </Button>
+      ),
+      label: 'sm',
+    },
+    {
+      component: <Button w="fit-content"> Medium Button</Button>,
+      label: 'md (default)',
+    },
+  ];
+
+  const withIcons = [
+    {
+      component: (
+        <Button leftIcon={<AddIcon />} w="fit-content">
+          Left icon
+        </Button>
+      ),
+      label: 'With left icon',
+    },
+    {
+      component: (
+        <Button rightIcon={<AddIcon />} w="fit-content">
+          Right icon
+        </Button>
+      ),
+      label: 'With right icon',
+    },
+    {
+      component: (
+        <Button leftIcon={<TokenIcon symbol="eth" />} variant="secondary" w="fit-content">
+          Token icon
+        </Button>
+      ),
+      label: 'With ETH token icon',
+    },
+    {
+      component: (
+        <Button rightIcon={<TokenIcon symbol="near" />} w="fit-content">
+          Token icon
+        </Button>
+      ),
+      label: 'With near icon',
+    },
+    {
+      component: (
+        <Button
+          leftIcon={<WalletIcon height="4" name="near" width="4" />}
+          variant="secondary"
+          w="fit-content"
+        >
+          Near wallet
+        </Button>
+      ),
+      label: 'With Near Wallet',
+    },
+    {
+      component: (
+        <Button rightIcon={<WalletIcon name="here" />} w="fit-content">
+          Here wallet
+        </Button>
+      ),
+      label: 'With HERE Wallet',
+    },
+    {
+      component: (
+        <Button leftIcon={<WalletIcon name="mynearwallet" />} variant="secondary" w="fit-content">
+          MyNearWallet
+        </Button>
+      ),
+      label: 'With MyNearWallet',
+    },
+    {
+      component: (
+        <Button variant="icon" w="fit-content">
+          <TokenIcon height="4" symbol="eth" width="4" />
+        </Button>
+      ),
+      label: 'ETH',
+    },
+    {
+      component: (
+        <Button variant="icon" w="fit-content">
+          <TokenIcon symbol="near" />
+        </Button>
+      ),
+      label: 'NEAR',
+    },
+  ];
+
+  const withImages = [
+    {
+      component: (
+        <Button
+          rightIcon={
+            <Image alt="keypom-logo" h="6" src={'https://docs.keypom.xyz/img/moon.png'} w="6" />
+          }
+          w="fit-content"
+        >
+          Moon
+        </Button>
+      ),
+      label: 'With Moon image on the left',
+    },
+    {
+      component: (
+        <Button
+          leftIcon={
+            <Image alt="keypom-logo" h="6" src={'https://docs.keypom.xyz/img/moon.png'} w="6" />
+          }
+          w="fit-content"
+        >
+          Moon
+        </Button>
+      ),
+      label: 'With Moon image on the right',
+    },
+    {
+      component: (
+        <Button variant="icon" w="fit-content">
+          <Image alt="keypom-logo" h="6" src={'https://docs.keypom.xyz/img/moon.png'} w="6" />
+        </Button>
+      ),
+      label: 'Moon',
+    },
+  ];
+  return (
+    <VStack spacing="40px" w="full">
+      <VStack spacing="20px" w="full">
+        <Heading>Button Variants</Heading>
+        <SimpleGrid columns={4} spacingX="10px" spacingY="20px" w="full">
+          {variants.map(({ component, label }) => (
+            <VStack key={label} spacing="4px">
+              {component}
+              <Text>{label}</Text>
+            </VStack>
+          ))}
+        </SimpleGrid>
+      </VStack>
+
+      <VStack spacing="20px" w="full">
+        <Heading>Button Sizes</Heading>
+        <SimpleGrid columns={4} spacingX="10px" spacingY="20px" w="full">
+          {sizes.map(({ component, label }) => (
+            <VStack key={label} spacing="4px">
+              {component}
+              <Text>{label}</Text>
+            </VStack>
+          ))}
+        </SimpleGrid>
+      </VStack>
+
+      <VStack spacing="20px" w="full">
+        <Heading>Button with Icons</Heading>
+        <SimpleGrid columns={4} spacingX="10px" spacingY="20px" w="full">
+          {withIcons.map(({ component, label }) => (
+            <VStack key={label} spacing="4px">
+              {component}
+              <Text>{label}</Text>
+            </VStack>
+          ))}
+        </SimpleGrid>
+      </VStack>
+
+      <VStack spacing="20px" w="full">
+        <Heading>Button with Images</Heading>
+        <SimpleGrid columns={4} spacingX="10px" spacingY="20px" w="full">
+          {withImages.map(({ component, label }) => (
+            <VStack key={label} spacing="4px">
+              {component}
+              <Text>{label}</Text>
+            </VStack>
+          ))}
+        </SimpleGrid>
+      </VStack>
+    </VStack>
+  );
+};

--- a/src/features/storybook/routes/StorybookPage.tsx
+++ b/src/features/storybook/routes/StorybookPage.tsx
@@ -1,0 +1,7 @@
+import { ButtonStory } from '../components/ButtonStory';
+
+const StorybookPage = () => {
+  return <ButtonStory />;
+};
+
+export default StorybookPage;

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -209,7 +209,6 @@ class KeypomJS {
       timeSinceGetDrop > 50000 ||
       start !== this.dropInformationMeta.lastPageIndex
     ) {
-      console.log('re-fetching getDrops');
       this.dropInformationMeta.lastFetch = currentTime;
       this.dropInformationMeta.lastPageIndex = start;
       this.dropInformationMeta.drops = await getDrops({ accountId, start, limit });

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -46,6 +46,16 @@ class KeypomJS {
   nearConnection: nearAPI.Near;
   test = 0;
 
+  dropInformationMeta: {
+    lastFetch: number;
+    lastPageIndex: number;
+    drops: ProtocolReturnedDrop[];
+  } = {
+    lastFetch: Date.now(),
+    lastPageIndex: Infinity,
+    drops: [],
+  };
+
   constructor() {
     if (instance !== undefined) {
       throw new Error('New instance cannot be created!!');
@@ -64,16 +74,6 @@ class KeypomJS {
     const { connect } = nearAPI;
 
     this.nearConnection = await connect(connectionConfig);
-  };
-
-  dropInformationMeta: {
-    lastFetch: number;
-    lastPageIndex: number;
-    drops: ProtocolReturnedDrop[];
-  } = {
-    lastFetch: Date.now(),
-    lastPageIndex: Infinity,
-    drops: [],
   };
 
   public static getInstance(): KeypomJS {
@@ -204,9 +204,10 @@ class KeypomJS {
     const currentTime = Date.now(); // in ms
     const timeSinceGetDrop = currentTime - this.dropInformationMeta.lastFetch;
 
+    /** Get Drops caching logic */
     if (
       this.dropInformationMeta.drops.length === 0 ||
-      timeSinceGetDrop > 50000 ||
+      timeSinceGetDrop > 5000 || // 5 seconds in MS
       start !== this.dropInformationMeta.lastPageIndex
     ) {
       this.dropInformationMeta.lastFetch = currentTime;

--- a/src/storybook-router.tsx
+++ b/src/storybook-router.tsx
@@ -1,0 +1,23 @@
+import { Box } from '@chakra-ui/react';
+import React from 'react';
+import { createBrowserRouter, Outlet } from 'react-router-dom';
+
+const StorybookPage = React.lazy(
+  async () => await import('@/features/storybook/routes/StorybookPage'),
+);
+
+export const router = createBrowserRouter([
+  {
+    element: (
+      <Box px="8" py="16">
+        <Outlet />
+      </Box>
+    ),
+    children: [
+      {
+        index: true,
+        element: <StorybookPage />,
+      },
+    ],
+  },
+]);


### PR DESCRIPTION
# Description
This PR handles:
- [x] add cache control to getDropInformation with 5 seconds validity, store drop info and timestamp in local storage, compare timestamp and revalidate
- [x] Add comments to Buttons component to improve readability

Fixes #185

# How to test
### Buttons storybook
1. `yarn run storybook`
2. Go to `localhost:3000`

### Add cache control:
1. Go to AllDrops.
2. Select any key in page 1, and go back to `My Drops` using the navigation button (to prevent reloading)

# Screenshots/Screen Recording of Implementation
See comments