### PR TITLE
Hotfix - amount per link not in decimal number and table border css ios issue

### DIFF
--- a/src/features/create-drop/components/token/CreateTokenDropForm.tsx
+++ b/src/features/create-drop/components/token/CreateTokenDropForm.tsx
@@ -148,7 +148,7 @@ export const CreateTokenDropForm = () => {
                 onChange={(e) => {
                   if (e.target.value.length > e.target.maxLength)
                     e.target.value = e.target.value.slice(0, e.target.maxLength);
-                  field.onChange(parseFloat(e.target.value));
+                  field.onChange(e.target.value);
                 }}
               >
                 <WalletBalanceInput.TokenMenu

--- a/src/features/create-drop/contexts/CreateTokenDropContext.tsx
+++ b/src/features/create-drop/contexts/CreateTokenDropContext.tsx
@@ -51,7 +51,7 @@ const schema = z.object({
     .positive()
     .min(1, 'Required')
     .max(50, 'Currently drops are limited to 50 links. This will be increased very soon!'),
-  amountPerLink: z.number({ invalid_type_error: 'Amount required' }).gt(0),
+  amountPerLink: z.coerce.number({ invalid_type_error: 'Amount required' }).gt(0),
   redirectLink: z
     .union([z.string().regex(urlRegex, 'Please enter a valid url'), z.string().length(0)])
     .optional(),

--- a/src/theme/components/TableTheme.ts
+++ b/src/theme/components/TableTheme.ts
@@ -8,7 +8,7 @@ export const TableTheme = helpers.defineMultiStyleConfig({
   baseStyle: {
     table: {
       bg: 'border.box',
-      border: '2px solid transparent',
+      border: '2px solid white',
       borderRadius: '8xl',
       borderCollapse: 'collapse',
       borderSpacing: 0,


### PR DESCRIPTION
# Description
- Fixes amount per link field in iOS which are not showing decimal number
- Fixes table border css ios that are not rounded

# How to test
Show steps to replicate and test the feature/fixes in this PR

1. Check out preview link on iOS Safari or Chrome
2. Create a token drop and ensure 0.453 or any decimal number 

# Screenshots/Screen Recording of Implementation
<img width="319" alt="Screenshot 2023-03-22 at 11 11 20 PM" src="https://user-images.githubusercontent.com/19740800/226952100-0e6867bd-7324-4e62-b77b-b1c937feb98c.png">

