### PR TITLE
Fix Create NFT Drop

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -17,7 +17,7 @@ export type DROP_TYPES = (typeof DROP_TYPE)[DROP_TYPE_KEYS];
 
 export const MASTER_KEY = 'MASTER_KEY';
 
-export const MAX_FILE_SIZE = 1000000;
+export const MAX_FILE_SIZE = 10000000;
 
 export const PAGE_SIZE_LIMIT = 10;
 export const NFT_ATTEMPT_KEY = 'NFT_ATTEMPT';

--- a/src/features/create-drop/components/nft/CreateNftDropForm.tsx
+++ b/src/features/create-drop/components/nft/CreateNftDropForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Button, Flex, VStack } from '@chakra-ui/react';
 
@@ -57,7 +57,7 @@ export const CreateNftDropForm = () => {
         <VStack spacing={{ base: '4', md: '5' }}>
           <NftNameInput control={control} />
           <DescriptionInput control={control} />
-          <NumberInput control={control} />
+          <NumberInput control={control} label="Number of NFTs" />
 
           <ArtworkInput />
 

--- a/src/features/create-drop/components/nft/Fields/NumberInput.tsx
+++ b/src/features/create-drop/components/nft/Fields/NumberInput.tsx
@@ -6,11 +6,12 @@ import { type CreateNftDropFormFieldTypes } from '../CreateNftDropForm';
 
 interface NumberInputProps {
   control: Control<CreateNftDropFormFieldTypes, any>;
+  label?: string;
 }
 
 const FIELD_NAME = 'number';
 
-export const NumberInput = ({ control }: NumberInputProps) => {
+export const NumberInput = ({ control, label = 'Number' }: NumberInputProps) => {
   return (
     <Controller
       control={control}
@@ -19,7 +20,7 @@ export const NumberInput = ({ control }: NumberInputProps) => {
         <TextInput
           errorMessage={error?.message}
           isInvalid={!!error?.message}
-          label="Number"
+          label={label}
           type="number"
           value={value || ''}
           {...fieldProps}

--- a/src/features/landing/components/DropsSection.tsx
+++ b/src/features/landing/components/DropsSection.tsx
@@ -64,11 +64,11 @@ export const DropsSection = () => {
       icon: <ImageIcon height={{ base: '6', md: '7' }} width={{ base: '6', md: '7' }} />,
       content: (
         <DropsTemplate
-          ctaDisabled={true}
+          ctaDisabled={false}
           ctaOnClick={() => {
-            // dropCta('nft');
+            dropCta('nft');
           }}
-          ctaText="Coming soon"
+          ctaText="Create a NFT Drop"
           description="Easily drop NFTs to a large audience, without needing their wallets."
           headingText="NFTs in a link."
           imageNumber={2}


### PR DESCRIPTION
# Description
1. change nft image upload limit from 1 MB to 10 MB
2. landing page's create NFT button is now enabled
3. Number of NFTs label changed

Fixes # (issue)

# How to test
Show steps to replicate and test the feature/fixes in this PR

1. checkout preview link
2. Create NFT drop

# Screenshots/Screen Recording of Implementation
