### PR TITLE
fixed redirect URL problem with undefined and MNW

### DIFF
--- a/src/features/claim/components/CreateWallet.tsx
+++ b/src/features/claim/components/CreateWallet.tsx
@@ -43,7 +43,7 @@ export const CreateWallet = ({
         }
       }, 20000);
 
-      wRef.location.href = `${url}?redirectUrl=${redirectUrl}`;
+      wRef.location.href = `${url}`; // ?redirectUrl=${redirectUrl}`;
     } catch (err) {
       // drop has been claimed
       // refresh to show error

--- a/src/features/claim/components/CreateWallet.tsx
+++ b/src/features/claim/components/CreateWallet.tsx
@@ -43,7 +43,7 @@ export const CreateWallet = ({
         }
       }, 20000);
 
-      wRef.location.href = `${url}`; // ?redirectUrl=${redirectUrl}`;
+      wRef.location.href = redirectUrl ? `${url}?redirectUrl=${redirectUrl}` : `${url}`;
     } catch (err) {
       // drop has been claimed
       // refresh to show error

--- a/src/features/claim/components/TokenNFTClaim.tsx
+++ b/src/features/claim/components/TokenNFTClaim.tsx
@@ -24,6 +24,7 @@ interface TokenNFTClaimProps {
 
   type: DROP_TYPES;
   wallets?: string[];
+  redirectUrl?: string;
   metadata: {
     title?: string;
     nftImage?: string;
@@ -46,6 +47,7 @@ export const TokenNFTClaim = ({
   type,
   metadata,
   wallets,
+  redirectUrl,
 }: TokenNFTClaimProps) => {
   const { setAppModal } = useAppContext();
   const [haveWallet, showInputWallet] = useBoolean(false);
@@ -160,6 +162,7 @@ export const TokenNFTClaim = ({
               {!haveWallet ? (
                 <CreateWallet
                   contractId={contractId}
+                  redirectUrl={redirectUrl}
                   secretKey={secretKey}
                   wallets={wallets}
                   onClick={showInputWallet.on}

--- a/src/features/claim/routes/NFTClaimPage.tsx
+++ b/src/features/claim/routes/NFTClaimPage.tsx
@@ -19,6 +19,7 @@ const NFTClaimPage = () => {
   const [description, setDescription] = useState('');
   const [nftImage, setNftImage] = useState('');
   const [wallets, setWallets] = useState([]);
+  const [redirectUrl, setRedirectUrl] = useState(undefined);
   const [tokens, setTokens] = useState<TokenAsset[]>([]);
 
   // claim info
@@ -57,6 +58,7 @@ const NFTClaimPage = () => {
       }
 
       setWallets(data.wallets);
+      setRedirectUrl(data.redirectUrl);
     } catch (err) {
       setClaimInfoError(err.message);
     }
@@ -94,6 +96,7 @@ const NFTClaimPage = () => {
       pageHeadingText={
         type === DROP_TYPE.NFT ? "You've received an NFT!" : "You've received a Keypom drop!"
       }
+      redirectUrl={redirectUrl}
       secretKey={secretKey}
       type={type}
       wallets={wallets}

--- a/src/lib/keypom.ts
+++ b/src/lib/keypom.ts
@@ -401,6 +401,7 @@ class KeypomJS {
     return {
       dropName: dropMetadata.dropName,
       wallets: dropMetadata.wallets,
+      redirectUrl: dropMetadata.redirectUrl,
       ftMetadata,
       amountTokens: drop.ft?.balance_per_use, // TODO: format correctly with FT metadata
       amountNEAR: formatNearAmount(drop.deposit_per_use, 4),
@@ -474,6 +475,7 @@ class KeypomJS {
       type: nftData ? DROP_TYPE.NFT : DROP_TYPE.TOKEN,
       dropName: dropMetadata.dropName,
       wallets: dropMetadata.wallets,
+      redirectUrl: dropMetadata.redirectUrl,
       ...(nftData
         ? {
             media: `${CLOUDFLARE_IPFS}/${nftData.metadata.media}`, // eslint-disable-line
@@ -519,6 +521,7 @@ class KeypomJS {
       type: nftData ? DROP_TYPE.NFT : DROP_TYPE.TOKEN,
       dropName: dropMetadata.dropName,
       wallets: dropMetadata.wallets,
+      redirectUrl: dropMetadata.redirectUrl,
       ...(nftData
         ? {
             media: `${CLOUDFLARE_IPFS}/${nftData.metadata.media}`, // eslint-disable-line


### PR DESCRIPTION
Added support for a redirect URL if it's present in the drop metadata.

If redirectUrl is set to undefined, it breaks things in MNW so if it's not present in the metadata, it shouldn't be part of the URL