### PR TITLE
Min/stripe connect quick fix

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -65,7 +65,7 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     const setPriceWithFallback = async () => {
-      // if (fetchAttempts < 10) {
+      if (fetchAttempts < 50) {
         const binancePrice = await fetchPrice(
           'https://api.binance.com/api/v3/ticker/price?symbol=NEARUSDT',
           (data) => data.price,
@@ -102,16 +102,16 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
           setNearPrice(parseFloat(coinlorePrice));
         }
 
-        // const coingeckoPrice = await fetchPrice(
-        //   'https://api.coingecko.com/api/v3/simple/price?ids=near&vs_currencies=usd',
-        //   (data) => data.near.usd,
-        // );
+        const coingeckoPrice = await fetchPrice(
+          'https://api.coingecko.com/api/v3/simple/price?ids=near&vs_currencies=usd',
+          (data) => data.near.usd,
+        );
 
-        // if (coingeckoPrice !== null) {
-        //   setNearPrice(coingeckoPrice);
-        //   return;
-        // }
-      // }
+        if (coingeckoPrice !== null) {
+          setNearPrice(coingeckoPrice);
+          return;
+        }
+      }
     };
 
     if (triggerPriceFetch) {

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -109,7 +109,6 @@ export const AppContextProvider = ({ children }: PropsWithChildren) => {
 
         if (coingeckoPrice !== null) {
           setNearPrice(coingeckoPrice);
-          return;
         }
       }
     };

--- a/src/features/create-drop/components/ticket/AcceptPaymentForm.tsx
+++ b/src/features/create-drop/components/ticket/AcceptPaymentForm.tsx
@@ -68,30 +68,6 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
       return stripeAccountIdObj[`${accountId}`] || null;
     }
   };
-  
-  // useEffect(() => {
-  //   console.log(formData);
-
-  // }, [formData.stripeAccountId]);
-
-  //   const stripeAccountId = localStorage.getItem('STRIPE_ACCOUNT_ID');
-  //   if (!stripeAccountId) {
-  //     return stripeAccountId;
-  //   }else{
-  //     const stripeAccountIdObj = JSON.parse(stripeAccountId);
-  //     if(stripeAccountIdObj[`${accountId}`] === undefined){
-  //       const loggedInStripeAccountId = stripeAccountIdObj[`${accountId}`];
-  //       if(loggedInStripeAccountId) {
-  //         setFormData({ ...formData, stripeAccountId: loggedInStripeAccountId, acceptStripePayments: false });
-  //         return loggedInStripeAccountId;
-  //       }else{
-  //         return null
-  //       }
-  //     }else{
-  //       return stripeAccountIdObj[`${accountId}`];
-  //     }
-  //   }
-  // };
 
   useEffect(() => {
     console.log("useEffect 1: ", formData)
@@ -101,8 +77,6 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
       if (window.location.href.includes(`successMessage=${uuid as string}`)) {
         localStorage.removeItem('STRIPE_ACCOUNT_INFO');
         setFormData({ ...formData, stripeAccountId, acceptStripePayments: true });
-        // make returned stripe account id temporarily available for local storage. Will be removed once saved
-        // setTempStripeId(stripeAccountId);
       }
     }
     let temp_stripe_account_id = localStorage.getItem('TEMP_STRIPE_ACCOUNT_ID');
@@ -123,13 +97,6 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
 
         // Store the updated object back to local storage
         localStorage.setItem('STRIPE_ACCOUNT_ID', JSON.stringify(existingStripeAccountInfoObj));
-        // let existingStripeAccoountInfo = localStorage.getItem('STRIPE_ACCOUNT_ID');
-        // if (!existingStripeAccoountInfo) {
-        //   existingStripeAccoountInfo = "{}";
-        // }
-        // let existingStripeAccoountInfoObj = JSON.parse(existingStripeAccoountInfo);
-        // existingStripeAccoountInfoObj[`${accountId}`] = formData.stripeAccountId;
-        // localStorage.setItem('STRIPE_ACCOUNT_ID', JSON.stringify(existingStripeAccoountInfoObj));
       }
     }
 

--- a/src/features/create-drop/components/ticket/AcceptPaymentForm.tsx
+++ b/src/features/create-drop/components/ticket/AcceptPaymentForm.tsx
@@ -77,8 +77,8 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
     const temp_stripe_account_id = localStorage.getItem('TEMP_STRIPE_ACCOUNT_ID');
     if (temp_stripe_account_id) {
       setFormData({ ...formData, stripeAccountId: temp_stripe_account_id});
-      localStorage.removeItem('TEMP_STRIPE_ACCOUNT_ID');
     }
+    localStorage.removeItem('TEMP_STRIPE_ACCOUNT_ID');
   }, []);
 
   useEffect(() => {

--- a/src/features/create-drop/components/ticket/AcceptPaymentForm.tsx
+++ b/src/features/create-drop/components/ticket/AcceptPaymentForm.tsx
@@ -55,22 +55,17 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
       return null
     }
     const stripeAccountId = localStorage.getItem('STRIPE_ACCOUNT_ID');
-    console.log("check for prior ", formData)
     if (!stripeAccountId) {
       return null;
     } else {
       const stripeAccountIdObj = JSON.parse(stripeAccountId);
-      let loggedInStripeAccountId = stripeAccountIdObj[`${accountId}`];
-      console.log("check for prior1 ", loggedInStripeAccountId)
+      const loggedInStripeAccountId = stripeAccountIdObj[`${accountId}`];
       setFormData({ ...formData, stripeAccountId: loggedInStripeAccountId, acceptStripePayments: false });
-      console.log("check for prior2 ", loggedInStripeAccountId)
-      console.log("check again: ", formData)
       return stripeAccountIdObj[`${accountId}`] || null;
     }
   };
 
   useEffect(() => {
-    console.log("useEffect 1: ", formData)
     const body = localStorage.getItem('STRIPE_ACCOUNT_INFO');
     if (body) {
       const { stripeAccountId, uuid } = JSON.parse(body);
@@ -79,7 +74,7 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
         setFormData({ ...formData, stripeAccountId, acceptStripePayments: true });
       }
     }
-    let temp_stripe_account_id = localStorage.getItem('TEMP_STRIPE_ACCOUNT_ID');
+    const temp_stripe_account_id = localStorage.getItem('TEMP_STRIPE_ACCOUNT_ID');
     if (temp_stripe_account_id) {
       setFormData({ ...formData, stripeAccountId: temp_stripe_account_id});
       localStorage.removeItem('TEMP_STRIPE_ACCOUNT_ID');
@@ -88,8 +83,8 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
 
   useEffect(() => {
     if(accountId){
-      let existingStripeAccountInfo = localStorage.getItem('STRIPE_ACCOUNT_ID');
-      let existingStripeAccountInfoObj = existingStripeAccountInfo ? JSON.parse(existingStripeAccountInfo) : {};
+      const existingStripeAccountInfo = localStorage.getItem('STRIPE_ACCOUNT_ID');
+      const existingStripeAccountInfoObj = existingStripeAccountInfo ? JSON.parse(existingStripeAccountInfo) : {};
 
       if(existingStripeAccountInfoObj[`${accountId}`] === undefined){
         // Update existing object with new stripeAccountId
@@ -146,10 +141,10 @@ const AcceptPaymentForm = (props: EventStepFormProps) => {
       if (!existingStripeAccoountInfo) {
         existingStripeAccoountInfo = "{}";
       }
-      let existingStripeAccoountInfoObj = JSON.parse(existingStripeAccoountInfo);
-      existingStripeAccoountInfoObj[`${accountId}`] = stripeAccountId;
+      const existingStripeAccountInfoObj = JSON.parse(existingStripeAccoountInfo);
+      existingStripeAccountInfoObj[`${accountId}`] = stripeAccountId;
 
-      localStorage.setItem('STRIPE_ACCOUNT_ID', JSON.stringify(existingStripeAccoountInfoObj));
+      localStorage.setItem('STRIPE_ACCOUNT_ID', JSON.stringify(existingStripeAccountInfoObj));
       return;
     }
 


### PR DESCRIPTION
# Description
1) Now, when connecting Stripe account but not creating an event, the Stripe account ID is still stored in local storage, allowing the user to quickly reconnect their Stripe account
2) Local storage STRIPE_ACCOUNT_ID changed to a map `${accountId}: ${stripeAccountId}` rather than storing a single `stripeAccountId`

# How to test
1) Log in, connect a Stripe account, leave the page before creating an event, then come back. You should still be signed in. 
2) Log in with another wallet, then repeat the steps and ensure local storage has two keys for stripe IDs. 
