### PR TITLE
small change to improve toast error on ticket purhase failure

### DIFF
--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -510,7 +510,7 @@ export default function Event() {
         } else {
           console.log("error: ", responseBody.error)
           if (typeof responseBody.error === 'object') {
-            let near_error = JSON.parse(responseBody.error.message)
+            const near_error = JSON.parse(responseBody.error.message)
             TicketPurchaseFailure(workerPayload,  near_error);
           }else{
             TicketPurchaseFailure(workerPayload, responseBody.error);
@@ -843,7 +843,7 @@ export default function Event() {
           TicketPurchaseSuccessful(newWorkerPayload, responseBody);
         } else {
           // Error creating account
-          let error = responseBody.error;
+          const error = responseBody.error;
           TicketPurchaseFailure(newWorkerPayload, error);
         }
       }

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -504,13 +504,17 @@ export default function Event() {
           },
         );
 
+        const responseBody = await response.json();
         if (response.ok) {
-          const responseBody = await response.json();
           TicketPurchaseSuccessful(workerPayload, responseBody);
         } else {
-          const responseBody = await response.json();
-          console.error('responseBody', responseBody);
-          TicketPurchaseFailure(workerPayload, await response.json());
+          console.log("error: ", responseBody.error)
+          if (typeof responseBody.error === 'object') {
+            let near_error = JSON.parse(responseBody.error.message)
+            TicketPurchaseFailure(workerPayload,  near_error);
+          }else{
+            TicketPurchaseFailure(workerPayload, responseBody.error);
+          }
         }
       } else {
         // secondary
@@ -736,15 +740,17 @@ export default function Event() {
         body: JSON.stringify(workerPayload),
       });
       if (response.ok) {
-        // Account created successfully
+        // Checkout created successfully
         const responseBody = await response.json();
 
         const stripeUrl = responseBody.stripe_url;
         window.location.href = stripeUrl;
         TicketPurchaseSuccessful(workerPayload, responseBody);
       } else {
-        // Error creating account
-        TicketPurchaseFailure(workerPayload, await response.json());
+        // Error creating checkout
+        const responseBody = await response.json();
+        console.log("error: ", responseBody.error)
+        TicketPurchaseFailure(workerPayload, responseBody.error);
       }
     }
   };
@@ -832,12 +838,13 @@ export default function Event() {
 
         currentLoadedKey++;
 
+        const responseBody = await response.json();
         if (response.ok) {
-          const responseBody = await response.json();
           TicketPurchaseSuccessful(newWorkerPayload, responseBody);
         } else {
           // Error creating account
-          TicketPurchaseFailure(newWorkerPayload, await response.json());
+          let error = responseBody.error;
+          TicketPurchaseFailure(newWorkerPayload, error);
         }
       }
     } else if (purchaseType === 'secondary') {


### PR DESCRIPTION
# Description
Fixed purchase modal fail not showing on free tickets. Better parsing responses from worker according to possible returns

# How to test
1) Create event with sale not yet start (or take [this](https://min-ticket-purhcase-error-im.keypom-airfoil.pages.dev/gallery/mintickt_testing.testnet:1712305137042) one from Guille)
2) Purchase free ticket. Toast should pop with sale time error (should be stringified object)
