### PR TITLE
Min/sale valid thru UI

### DIFF
--- a/src/features/drop-manager/utils/parseDates.tsx
+++ b/src/features/drop-manager/utils/parseDates.tsx
@@ -12,7 +12,6 @@ export const dateAndTimeToText = (date: DateAndTimeInfo, placeholder = '') => {
   const startYear = start.getFullYear();
   const startMonth = start.toLocaleDateString(undefined, { month: 'short' });
   const startDay = start.toLocaleDateString(undefined, { day: 'numeric' });
-  console.log(date.startDate)
   // Extract the time zone from the start date and use it at the end
   timeZone = start.toLocaleDateString(undefined, { timeZoneName: 'short' }).split(', ').pop() || '';
 

--- a/src/features/drop-manager/utils/parseDates.tsx
+++ b/src/features/drop-manager/utils/parseDates.tsx
@@ -12,7 +12,7 @@ export const dateAndTimeToText = (date: DateAndTimeInfo, placeholder = '') => {
   const startYear = start.getFullYear();
   const startMonth = start.toLocaleDateString(undefined, { month: 'short' });
   const startDay = start.toLocaleDateString(undefined, { day: 'numeric' });
-
+  console.log(date.startDate)
   // Extract the time zone from the start date and use it at the end
   timeZone = start.toLocaleDateString(undefined, { timeZoneName: 'short' }).split(', ').pop() || '';
 

--- a/src/features/gallery/components/TicketCard.tsx
+++ b/src/features/gallery/components/TicketCard.tsx
@@ -193,11 +193,11 @@ export const TicketCard = ({ event, loading, surroundingNavLink, onSubmit }: Tic
       const noEndDate = salesValidInfoObj.endDate === undefined || salesValidInfoObj.endDate === null;
 
       if (noEndDate) {
-        saleTimeString = `Tickets sales open: ${dateAndTimeToText(
+        saleTimeString = `Ticket sales open: ${dateAndTimeToText(
           salesValidInfoObj,
         )}.`
       }else{
-        saleTimeString = `Tickets be can bought during: ${dateAndTimeToText(
+        saleTimeString = `Sales: ${dateAndTimeToText(
           salesValidInfoObj,
         )}.`
       }

--- a/src/features/gallery/components/TicketCard.tsx
+++ b/src/features/gallery/components/TicketCard.tsx
@@ -22,7 +22,7 @@ import { PURCHASED_LOCAL_STORAGE_PREFIX } from '@/constants/common';
 
 
 import { TicketIncrementer } from './TicketIncrementer';
-import { DateAndTimeInfo } from '@/lib/eventsHelpers';
+import { type DateAndTimeInfo } from '@/lib/eventsHelpers';
 import { validateEndDateAndTime, validateStartDateAndTime } from '@/features/scanner/components/helpers';
 import { dateAndTimeToText } from '@/features/drop-manager/utils/parseDates';
 
@@ -190,7 +190,7 @@ export const TicketCard = ({ event, loading, surroundingNavLink, onSubmit }: Tic
     const salesValidInfo = event.salesValidThrough.valueOf();
     if(typeof salesValidInfo === "object"){
       const salesValidInfoObj = salesValidInfo as DateAndTimeInfo;
-      let noEndDate = salesValidInfoObj.endDate === undefined || salesValidInfoObj.endDate === null;
+      const noEndDate = salesValidInfoObj.endDate === undefined || salesValidInfoObj.endDate === null;
 
       if (noEndDate) {
         saleTimeString = `Tickets sales open: ${dateAndTimeToText(
@@ -354,7 +354,7 @@ export const TicketCard = ({ event, loading, surroundingNavLink, onSubmit }: Tic
           ) : (
             <>
             {!saleTimeValid && (
-              <Text color="red" fontSize="xs" fontWeight="400" align="left">
+              <Text align="left" color="red" fontSize="xs" fontWeight="400" >
                 {`${saleTimeString}`}
               </Text>
               )}

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -118,6 +118,7 @@ export interface EventInterface {
   dateString: string | undefined;
   price: number | undefined;
   dateForPastCheck: Date | undefined;
+  salesValidThrough: DateAndTimeInfo | undefined;
 }
 
 export interface ResaleTicketInfo {
@@ -1177,6 +1178,7 @@ export default function Event() {
           dateString: '',
           price: 0,
           dateForPastCheck: new Date(),
+          salesValidThrough: undefined,
         });
         setIsLoading(false);
       } catch (error) {


### PR DESCRIPTION
# Description
When sale times are not valid, the buy button is disabled and some info text above it shows the valid period

# How to test
Vist [here](https://min-sale-valid-thru-UI.keypom-airfoil.pages.dev/gallery/mintickt_testing.testnet:1712305137042), sale should show invalid

<img width="335" alt="image" src="https://github.com/keypom/keypom-frontend/assets/59981815/86dad481-d468-4c9c-87a9-f782f82cb78f">
