### PR TITLE
small fixes to integrate with new metadata appending scheme

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -30,8 +30,8 @@ export const EMAIL_WORKER_BASE = 'https://email-worker.keypom.workers.dev';
 export const PAGE_SIZE_LIMIT = 5;
 export const NFT_ATTEMPT_KEY = 'NFT_ATTEMPT';
 export const PAGE_QUERY_PARAM = 'page';
-export const KEYPOM_EVENTS_CONTRACT = '1711377493739-kp-ticketing.testnet';
-export const KEYPOM_MARKETPLACE_CONTRACT = '1711377493739-marketplace.testnet';
+export const KEYPOM_EVENTS_CONTRACT = '1714456631066-kp-ticketing.testnet';
+export const KEYPOM_MARKETPLACE_CONTRACT = '1714456631066-marketplace.testnet';
 // export const KEYPOM_EVENTS_CONTRACT = '1711377493739-kp-ticketing.testnet';
 // export const KEYPOM_MARKETPLACE_CONTRACT = '1711377493739-marketplace.testnet';
 

--- a/src/features/create-drop/components/ticket/helpers.tsx
+++ b/src/features/create-drop/components/ticket/helpers.tsx
@@ -307,7 +307,7 @@ export const createPayload = async ({
     marketTicketInfo: ticket_information,
   });
 
-  let change_user_metadata = {};
+  const change_user_metadata = {};
   change_user_metadata[eventId] = eventMetadata;
 
   const actions: Action[] = [

--- a/src/features/create-drop/components/ticket/helpers.tsx
+++ b/src/features/create-drop/components/ticket/helpers.tsx
@@ -307,6 +307,9 @@ export const createPayload = async ({
     marketTicketInfo: ticket_information,
   });
 
+  var change_user_metadata = {};
+  change_user_metadata[eventId] = eventMetadata;
+
   const actions: Action[] = [
     {
       type: 'FunctionCall',
@@ -316,7 +319,7 @@ export const createPayload = async ({
           drop_ids,
           drop_configs,
           asset_datas,
-          change_user_metadata: JSON.stringify(funderMetadata),
+          change_user_metadata: JSON.stringify(change_user_metadata),
           on_success: {
             receiver_id: KEYPOM_MARKETPLACE_CONTRACT,
             method_name: 'create_event',

--- a/src/features/create-drop/components/ticket/helpers.tsx
+++ b/src/features/create-drop/components/ticket/helpers.tsx
@@ -307,7 +307,7 @@ export const createPayload = async ({
     marketTicketInfo: ticket_information,
   });
 
-  var change_user_metadata = {};
+  let change_user_metadata = {};
   change_user_metadata[eventId] = eventMetadata;
 
   const actions: Action[] = [


### PR DESCRIPTION
Sending contract one event at a time, rather than all of funder metadata, as per [this contract PR](https://github.com/keypom/fydp-contracts/pull/2)
